### PR TITLE
Summarizer Evaluation Handling Different Word Tokenizers [resolves #63], [resolves #70]

### DIFF
--- a/sadedegel/summarize/__init__.py
+++ b/sadedegel/summarize/__init__.py
@@ -1,3 +1,4 @@
 from .baseline import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer  # noqa: F401
 from .rouge import Rouge1Summarizer  # noqa: F401
 from .cluster import KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer  # noqa: F401
+from .__main__ import evaluate, filter_summary

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from math import ceil
-from typing import List
+from typing import List, Union
 
 from tqdm import tqdm  # type: ignore
 
@@ -13,6 +13,18 @@ from ..dataset import load_annotated_corpus
 from ..summarize import RandomSummarizer, PositionSummarizer, Rouge1Summarizer, KMeansSummarizer, AutoKMeansSummarizer, \
     DecomposedKMeansSummarizer, LengthSummarizer
 from ..bblock import Sentences, Doc
+from sadedegel import tokenizer_context
+
+
+_all = [('Random Summarizer', RandomSummarizer()), ('FirstK Summarizer', PositionSummarizer()),
+        ('LastK Summarizer', PositionSummarizer('last')), ('Rouge1 Summarizer (f1)', Rouge1Summarizer()),
+        ('Rouge1 Summarizer (precision)', Rouge1Summarizer('precision')),
+        ('Rouge1 Summarizer (recall)', Rouge1Summarizer('recall')),
+        ('Length Summarizer (char)', LengthSummarizer('token')),
+        ('Length Summarizer (token)', LengthSummarizer('char')),
+        ('KMeans Summarizer', KMeansSummarizer()),
+        ('AutoKMeans Summarizer', AutoKMeansSummarizer()),
+        ('DecomposedKMeans Summarizer', DecomposedKMeansSummarizer())]
 
 
 def to_sentence_list(sents: List[str]) -> List[Sentences]:
@@ -24,6 +36,16 @@ def to_sentence_list(sents: List[str]) -> List[Sentences]:
     return l
 
 
+def filter_summary(tags: Union[str, List[str]]):
+
+    if type(tags) == str:
+        tags = [tags]
+
+    summs = [summ for tag in tags for summ in _all if tag in summ[1].tags]
+
+    return summs
+
+
 @click.group(help="SadedeGel summarizer commandline")
 def cli():
     pass
@@ -31,34 +53,32 @@ def cli():
 
 @cli.command()
 @click.option("-f", "--table-format", default="github")
-def evaluate(table_format):
+@click.option("-t", "--tag", default="extractive", multiple=True)
+@click.option("-wt", "--word-tokenizer", default="bert")
+@click.option("-d", "--debug", default=False)
+def evaluate(table_format, tag, word_tokenizer, debug):
     """Evaluate all summarizers in sadedeGel"""
-    anno = load_annotated_corpus()
+
+    anno_corp = load_annotated_corpus()
+    anno = list(anno_corp)
+    summarizers = filter_summary(tag)
 
     scores = defaultdict(list)
-    for name, summarizer in tqdm(
-            [('Random Summarizer', RandomSummarizer()), ('FirstK Summarizer', PositionSummarizer()),
-             ('LastK Summarizer', PositionSummarizer('last')), ('Rouge1 Summarizer (f1)', Rouge1Summarizer()),
-             ('Rouge1 Summarizer (precision)', Rouge1Summarizer('precision')),
-             ('Rouge1 Summarizer (recall)', Rouge1Summarizer('recall')),
-             ('Length Summarizer (char)', LengthSummarizer('token')),
-             ('Length Summarizer (token)', LengthSummarizer('char')),
-             ('KMeans Summarizer', KMeansSummarizer()),
-             ('AutoKMeans Summarizer', AutoKMeansSummarizer()),
-             ('DecomposedKMeans Summarizer', DecomposedKMeansSummarizer())], unit=" method",
-            desc="Evaluate all summarization methods"):
-        for doc in tqdm(anno, unit=" doc", desc=f"Calculate n-dcg score for {name}"):
-            y_true = [doc['relevance']]
 
-            d = Doc.from_sentences(doc['sentences'])
+    with tokenizer_context(word_tokenizer):
+        for name, summarizer in tqdm(summarizers, unit=" method", desc="Evaluate all summarization methods"):
+            for doc in tqdm(anno, unit=" doc", desc=f"Calculate n-dcg score for {name}"):
+                y_true = [doc['relevance']]
 
-            y_pred = [summarizer.predict(d.sents)]
+                d = Doc.from_sentences(doc['sentences'])
 
-            score_10 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.1))
-            score_50 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.5))
-            score_80 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.8))
+                y_pred = [summarizer.predict(d.sents)]
 
-            scores[name].append((score_10, score_50, score_80))
+                score_10 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.1))
+                score_50 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.5))
+                score_80 = ndcg_score(y_true, y_pred, k=ceil(len(doc['sentences']) * 0.8))
+
+                scores[name].append((score_10, score_50, score_80))
 
     table = [[algo, np.array([s[0] for s in scores]).mean(), np.array([s[1] for s in scores]).mean(),
               np.array([s[2] for s in scores]).mean()] for
@@ -68,6 +88,9 @@ def evaluate(table_format):
     print(
         tabulate(table, headers=['Method', 'ndcg(k=0.1)', 'ndcg(k=0.5)', 'ndcg(k=0.8)'], tablefmt=table_format,
                  floatfmt=".4f"))
+
+    if debug:
+        click.echo(np.array(table).shape)
 
 
 if __name__ == '__main__':

--- a/tests/summarizer/context.py
+++ b/tests/summarizer/context.py
@@ -6,5 +6,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.summarize import KMeansSummarizer,AutoKMeansSummarizer,DecomposedKMeansSummarizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.summarize import evaluate, filter_summary
 from sadedegel import Doc, set_config, tokenizer_context # noqa # pylint: disable=unused-import, wrong
 from sadedegel.bblock import BertTokenizer, SimpleTokenizer # noqa # pylint: disable=unused-import, wrong

--- a/tests/summarizer/test_filter.py
+++ b/tests/summarizer/test_filter.py
@@ -1,0 +1,58 @@
+from .context import evaluate, filter_summary, SimpleTokenizer, BertTokenizer
+from click.testing import CliRunner
+import pytest
+
+
+@pytest.mark.parametrize("tag, summarizers", [("extractive", ['Random Summarizer', 'FirstK Summarizer',
+                                                              'LastK Summarizer', 'Rouge1 Summarizer (f1)',
+                                                              'Rouge1 Summarizer (precision)',
+                                                              'Rouge1 Summarizer (recall)',
+                                                              'Length Summarizer (char)',
+                                                              'Length Summarizer (token)',
+                                                              'KMeans Summarizer',
+                                                              'AutoKMeans Summarizer',
+                                                              'DecomposedKMeans Summarizer']),
+                                              ("baseline", ['Random Summarizer', 'FirstK Summarizer',
+                                                            'LastK Summarizer',
+                                                            'Length Summarizer (char)',
+                                                            'Length Summarizer (token)']),
+                                              ("self-supervised", ['Rouge1 Summarizer (f1)',
+                                                                   'Rouge1 Summarizer (precision)',
+                                                                   'Rouge1 Summarizer (recall)']),
+                                              ("ml",  ['Rouge1 Summarizer (f1)',
+                                                       'Rouge1 Summarizer (precision)',
+                                                       'Rouge1 Summarizer (recall)',
+                                                       'KMeans Summarizer',
+                                                       'AutoKMeans Summarizer',
+                                                       'DecomposedKMeans Summarizer'])])
+def test_tag_filter(tag, summarizers):
+
+    summ = filter_summary(tag)
+    summ = [s[0] for s in summ]
+    assert summ == summarizers
+
+
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(5, 4)"), (SimpleTokenizer.__name__, "(5, 4)")])
+def test_eval_baseline(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'baseline', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape
+
+
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(3, 4)"), (SimpleTokenizer.__name__, "(3, 4)")])
+def test_eval_selfsupervised(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'self-supervised', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape
+
+
+@pytest.mark.skip(reason="Takes long to test. "
+                         "User can decide not to skip if there are any changes in eval script or ML based summarizers.")
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(6, 4)"), (SimpleTokenizer.__name__, "(6, 4)")])
+def test_eval_ml(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'ml', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape


### PR DESCRIPTION
**Changes in `__main.py__`:**
* `evaluate` CLI option for `sadedegel-summarize` recieves `tag` argument to filter summarizers to evaluate based on their tags.
* `filter_summary` method is responsible to filter and return a list of selected summarizers.
* `evaluate` CLI option receives word tokenizer type as an argument by the user based on the context they want to evaluate the summarizers.
* Evaluation is itself a test, hence word-tokenizer config should not stay changed globally after evaluation, thus evaluation is done under `tokenizer_context` context manager.
* `--debug` argument is to return shape of the score table to be used in pytest. Test for evaluation script tests whether `evaluate` option of CLI, runs over all the summarizers that are filtered.
* When annotated corpus is loaded it is turned into a list so that it can be iterated over more than once without the need for reseting it.

**Addition of `test_filter.py`:**
* `test_tag_filter` checks wheter the correct summarizers are filtered and returned based on the tags.
* `test_eval_<word_tokenizer>` methods check wheter evaluate runs and returns the scores of all summarizers that are filtered and tested using CLI. This is done with all word tokenizers.