### PR TITLE
Summarizer Evaluation Handling Different Word Tokenizers [resolves #63]

### DIFF
--- a/sadedegel/summarize/README.md
+++ b/sadedegel/summarize/README.md
@@ -25,13 +25,23 @@ ground truth human annotation (Best possible total `relevance` score that can be
 
 [Normalized Discounted Cumulative Gain]: https://en.wikipedia.org/wiki/Discounted_cumulative_gain
 
+### Performance Evaluation
 
+Users can simply perform contrastive evaluation of the implemented summarizers running `sadedegel-summarize evaluate` on command line. 
+
+##### Options: 
+
+- `--tag | -t`: Each implemented summarizer has a built-in "tag" feature from the list `[extractive|baseline|self-supervised|ml]`. 
+User can provide subsets to include specific  summarizers and exclude the rest.
+- `--word-tokenizer | -wt`: Sadedegel incorporates two word tokenizers `bert` and `simple`. Default word tokenizer `bert` can be overriden for evaluating performance of summarizers subject to other built-in or user-defined word tokenizers.
+- `--debug | -db`: Set to `True` when evaluation CLI is tested with SadedeGel test suite. Just as new features are tested, their evaluation is also subject to unit tests. Addition of new summarizers or tags require the validation of the evaluation script as well. Refer to [CONTRIBUTING.md](https://github.com/GlobalMaksimum/sadedegel/blob/develop/CONTRIBUTING.md) for more on adding tests.  
 ### Performance Table
 
 #### Release 0.9
 * KMeans
 * AutoKMeansSummarizer
 * DecomposedKMeansSummarize
+* Backend word tokenizer: `BertTokenizer`
 
 | Method                     |   ndcg(k=0.1) |   ndcg(k=0.5) |   ndcg(k=0.8) |
 |----------------------------|---------------|---------------|---------------|
@@ -46,3 +56,22 @@ ground truth human annotation (Best possible total `relevance` score that can be
 | KMeans                     |        0.6569 |        0.7432 |        0.8336 |
 | AutoKMeansSummarizer       |        0.6576 |        0.7417 |        0.8324 |
 | DecomposedKMeansSummarizer |        0.6550 |        0.7436 |        0.8331 |
+
+#### Release 0.13.5
+* Backend word tokenizer: `SimpleTokenizer`
+
+| Method                        |   ndcg(k=0.1) |   ndcg(k=0.5) |   ndcg(k=0.8) |
+|-------------------------------|---------------|---------------|---------------|
+| Random Summarizer             |        0.5635 |        0.6649 |        0.7799 |
+| FirstK Summarizer             |        0.5033 |        0.6154 |        0.7411 |
+| LastK Summarizer              |        0.6048 |        0.6973 |        0.8013 |
+| Rouge1 Summarizer (f1)        |        0.6641 |        0.7461 |        0.8399 |
+| Rouge1 Summarizer (precision) |        0.4918 |        0.6311 |        0.7649 |
+| Rouge1 Summarizer (recall)    |        0.6671 |        0.7517 |        0.8447 |
+| Length Summarizer (char)      |        0.6669 |        0.7541 |        0.8469 |
+| Length Summarizer (token)     |        **0.6715** |        **0.7548** |        **0.8478** |
+| KMeans Summarizer             |        0.6569 |        0.7432 |        0.8336 |
+| AutoKMeans Summarizer         |        0.6576 |        0.7417 |        0.8324 |
+| DecomposedKMeans Summarizer   |        0.6555 |        0.7436 |        0.8331 |
+
+

--- a/sadedegel/summarize/__init__.py
+++ b/sadedegel/summarize/__init__.py
@@ -1,3 +1,4 @@
 from .baseline import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer  # noqa: F401
 from .rouge import Rouge1Summarizer  # noqa: F401
 from .cluster import KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer  # noqa: F401
+from .__main__ import evaluate, filter_summary

--- a/tests/summarizer/context.py
+++ b/tests/summarizer/context.py
@@ -6,5 +6,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.summarize import KMeansSummarizer,AutoKMeansSummarizer,DecomposedKMeansSummarizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.summarize import evaluate, filter_summary
 from sadedegel import Doc, set_config, tokenizer_context # noqa # pylint: disable=unused-import, wrong
 from sadedegel.bblock import BertTokenizer, SimpleTokenizer # noqa # pylint: disable=unused-import, wrong

--- a/tests/summarizer/test_filter.py
+++ b/tests/summarizer/test_filter.py
@@ -1,0 +1,58 @@
+from .context import evaluate, filter_summary, SimpleTokenizer, BertTokenizer
+from click.testing import CliRunner
+import pytest
+
+
+@pytest.mark.parametrize("tag, summarizers", [("extractive", ['Random Summarizer', 'FirstK Summarizer',
+                                                              'LastK Summarizer', 'Rouge1 Summarizer (f1)',
+                                                              'Rouge1 Summarizer (precision)',
+                                                              'Rouge1 Summarizer (recall)',
+                                                              'Length Summarizer (char)',
+                                                              'Length Summarizer (token)',
+                                                              'KMeans Summarizer',
+                                                              'AutoKMeans Summarizer',
+                                                              'DecomposedKMeans Summarizer']),
+                                              ("baseline", ['Random Summarizer', 'FirstK Summarizer',
+                                                            'LastK Summarizer',
+                                                            'Length Summarizer (char)',
+                                                            'Length Summarizer (token)']),
+                                              ("self-supervised", ['Rouge1 Summarizer (f1)',
+                                                                   'Rouge1 Summarizer (precision)',
+                                                                   'Rouge1 Summarizer (recall)']),
+                                              ("ml",  ['Rouge1 Summarizer (f1)',
+                                                       'Rouge1 Summarizer (precision)',
+                                                       'Rouge1 Summarizer (recall)',
+                                                       'KMeans Summarizer',
+                                                       'AutoKMeans Summarizer',
+                                                       'DecomposedKMeans Summarizer'])])
+def test_tag_filter(tag, summarizers):
+
+    summ = filter_summary(tag)
+    summ = [s[0] for s in summ]
+    assert summ == summarizers
+
+
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(5, 4)"), (SimpleTokenizer.__name__, "(5, 4)")])
+def test_eval_baseline(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'baseline', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape
+
+
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(3, 4)"), (SimpleTokenizer.__name__, "(3, 4)")])
+def test_eval_selfsupervised(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'self-supervised', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape
+
+
+@pytest.mark.skip(reason="Takes long to test. "
+                         "User can decide not to skip if there are any changes in eval script or ML based summarizers.")
+@pytest.mark.parametrize("tokenizer, true_shape",
+                         [(BertTokenizer.__name__, "(6, 4)"), (SimpleTokenizer.__name__, "(6, 4)")])
+def test_eval_ml(tokenizer, true_shape):
+    runner = CliRunner()
+    result = runner.invoke(evaluate, ['--debug', 'True', '--tag', 'ml', '-wt', f'{tokenizer}'])
+    assert result.output[-10:].rsplit('\n')[-2] == true_shape


### PR DESCRIPTION
Changes in **`__main.py__`**:

* evaluate CLI option for sadedegel-summarize recieves `--tag` option to filter summarizers to evaluate based on their tags.
* `def filter_summary(tags):` method is responsible to filter and return a list of selected summarizers.
* evaluate CLI option receives word tokenizer type as an argument by the user based on the context they want to evaluate the summarizers.
* Evaluation is itself a test, hence word-tokenizer config should not stay changed globally after evaluation, thus evaluation is done under `tokenizer_context` context manager.
* `--debug` option is to return shape of the score table to be used in `pytest`. `test_filter.py` for evaluation script tests whether evaluate option of CLI, runs over all the summarizers that are filtered.

Addition of **`test_filter.py`**:

* `test_tag_filter` checks wheter the correct summarizers are filtered and returned based on the tags.
* `test_eval_<word_tokenizer>` methods check whether evaluate runs and returns the scores of all summarizers that are filtered and tested using CLI. This is done with all word tokenizers.

Changes in **`summarize/README.md`**:

* Detailed the usage of `evaluate` command with its options.
* Explanation of summarizer tags added in Commit 8498ead and using them for filtering while running evaluation command on summarizers.
* Performance table of summarizers when word tokenizer is set as `SimpleTokenizer` in backend.