### PR TITLE
TF-IDF Summarizer

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+sadedegel.ai

--- a/sadedegel/summarize/__init__.py
+++ b/sadedegel/summarize/__init__.py
@@ -2,3 +2,4 @@ from .baseline import RandomSummarizer, PositionSummarizer, LengthSummarizer, Ba
 from .rouge import Rouge1Summarizer  # noqa: F401
 from .cluster import KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer  # noqa: F401
 from .rank import TextRank  # noqa: F401
+from .tf_idf import TFIDFSummarizer  # noqa: F401

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -9,10 +9,10 @@ import warnings
 import numpy as np  # type: ignore
 from sklearn.metrics import ndcg_score  # type: ignore
 
-from sadedegel.dataset import load_annotated_corpus
+from sadedegel.dataset import load_annotated_corpus, load_raw_corpus
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, Rouge1Summarizer, KMeansSummarizer, \
     AutoKMeansSummarizer, \
-    DecomposedKMeansSummarizer, LengthSummarizer, TextRank
+    DecomposedKMeansSummarizer, LengthSummarizer, TextRank, TFIDFSummarizer
 from sadedegel import Sentences, Doc
 from sadedegel import tokenizer_context
 
@@ -35,7 +35,8 @@ SUMMARIZERS = [('Random Summarizer', RandomSummarizer()), ('FirstK Summarizer', 
                ("TextRank(0.7) Summarizer (BERT)", TextRank(alpha=0.7)),
                ("TextRank(0.85) Summarizer (BERT)", TextRank(alpha=0.85)),
                ("TextRank(0.9) Summarizer (BERT)", TextRank(alpha=0.9)),
-               ("TextRank(0.95) Summarizer (BERT)", TextRank(alpha=0.95))]
+               ("TextRank(0.95) Summarizer (BERT)", TextRank(alpha=0.95)),
+               ((), ("extractive"))]
 
 
 def to_sentence_list(sents: List[str]) -> List[Sentences]:
@@ -81,6 +82,7 @@ def evaluate(table_format, tag, debug):
         click.echo("Word Tokenizer: " + click.style(f"{word_tokenizer}", fg="blue"))
         docs = [Doc.from_sentences(doc['sentences']) for doc in anno]  # Reset document because of memoization
         with tokenizer_context(word_tokenizer):
+            summarizers[20] = ('TFIDFSummarizer', TFIDFSummarizer(load_raw_corpus()))
             for name, summarizer in summarizers:
                 click.echo(click.style(f"    {name} ", fg="magenta"), nl=False)
                 # skip simple tokenizer for clustering models

--- a/sadedegel/summarize/tf_idf.py
+++ b/sadedegel/summarize/tf_idf.py
@@ -1,0 +1,43 @@
+from collections import defaultdict
+from typing import List
+from math import log
+import numpy as np
+
+from ..tokenize import Doc, Sentences
+from ._base import ExtractiveSummarizer
+
+
+class TFIDFSummarizer(ExtractiveSummarizer):
+    def __init__(self, all_docs: List[str], normalize=False):
+        super().__init__(normalize)
+        all_words_dict = defaultdict(lambda: 0)
+        doc_count = 0
+        for doc_str in all_docs:
+            doc = Doc(doc_str)
+            unique_words = set()
+            for sent in doc.sents:
+                for token in sent.tokens:
+                    unique_words.add(token)
+            for token in unique_words:
+                all_words_dict[token] += 1
+            doc_count += 1
+        self.all_words_dict = all_words_dict
+        self.doc_count = doc_count
+
+    def _predict(self, sents: List[Sentences]):
+        doc_word_dict = defaultdict(lambda: 0)
+        doc_word_count = 0
+        for sent in sents:
+            for token in sent.tokens:
+                doc_word_dict[token] += 1
+                doc_word_count += 1
+        scores = [None] * len(sents)
+        i = 0
+        for sent in sents:
+            scores[i] = []
+            for token in sent.tokens:
+                scores[i].append((doc_word_dict[token] / doc_word_count) * log(
+                                 (self.doc_count / (1 + self.all_words_dict[token]))))
+            scores[i] = sum(scores[i])
+            i += 1
+        return np.array(scores)

--- a/tests/summarizer/context.py
+++ b/tests/summarizer/context.py
@@ -7,5 +7,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.summarize import KMeansSummarizer,AutoKMeansSummarizer,DecomposedKMeansSummarizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.summarize import TextRank  # noqa # pylint: disable=unused-import, wrong
+from sadedegel.summarize import TFIDFSummarizer
 from sadedegel import Doc, set_config, tokenizer_context # noqa # pylint: disable=unused-import, wrong
 from sadedegel.bblock import BertTokenizer, SimpleTokenizer # noqa # pylint: disable=unused-import, wrong

--- a/tests/summarizer/test_tfidf.py
+++ b/tests/summarizer/test_tfidf.py
@@ -1,0 +1,14 @@
+from sadedegel.tokenize import Sentences
+from .context import TFIDFSummarizer, Doc
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("docs", [["Onu hiç sevmedim", "Bu iş çok zor"]])
+@pytest.mark.parametrize("inp_doc", [[Sentences(0, "Bu renk kötü",
+                                                Doc("Bu renk kötü. O araç güzel")),
+                                      Sentences(1, "O araç güzel",
+                                                Doc("Bu renk kötü. O araç güzel"))]])
+@pytest.mark.parametrize("result", [np.array([0.23104906, 0.34657359])])
+def test_tfidf(docs, inp_doc, result):
+    assert TFIDFSummarizer(docs).predict(inp_doc) == pytest.approx(result)


### PR DESCRIPTION
A new summarizar based on the TF-IDF. According to default evaluation function, TF-IDF Summarizer is better than the other summarizers but during the evaluation it uses load_raw_corpus function to get all the documents from the sadedegel/dataset/raw folder