### PR TITLE
Add Token Attributes to Token Class. [Resolves #98]

### DIFF
--- a/sadedegel/bblock/vocabulary.py
+++ b/sadedegel/bblock/vocabulary.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from math import log
 from json import dump, load
 from sadedegel.bblock.util import tr_lower
-
+from sadedegel.bblock.word_tokenizer_helper import puncts
 
 @dataclass
 class Token:
@@ -12,6 +12,28 @@ class Token:
     word: str
     df: int
     n_document: int
+
+    @property
+    def is_punct(self):
+        return self.word in puncts
+
+    @property
+    def is_digit(self):
+        return self.word.isdigit()
+
+    @property
+    def shape(self):
+        if self.is_digit:
+            shape = 'd' * len(self.word)
+        else:
+            shape = ''
+            for char in self.word:
+                if char.isupper():
+                    shape += 'X'
+                else:
+                    shape += 'x'
+
+        return shape
 
     @property
     def idf(self):

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,6 +7,7 @@ from sadedegel.dataset import load_raw_corpus, load_sentence_corpus  # noqa # py
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer  # noqa # pylint: disable=unused-import, wrong-import-position, line-too-long
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.bblock.vocabulary import Token # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.ml import create_model, load_model, save_model  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_token_attributes.py
+++ b/tests/test_token_attributes.py
@@ -1,0 +1,34 @@
+import pytest
+from .context import Token, Doc
+
+
+famous_quote = "Merhaba dünya. 36 ışıkyılı uzaktan geldik."
+
+
+def test_token():
+
+    d = Doc(famous_quote)
+    s = d.sents[0]
+    t = s.tokens[0]
+
+    assert isinstance(t) == str
+
+
+def test_is_digit():
+
+    t = Token(0, '123', 10, 100)
+    assert t.is_digit
+
+
+def test_is_punct():
+
+    t = Token(0, '!', 10, 100)
+    assert t.is_punct
+
+
+@pytest.mark.parametrize("word, shape", [('1969', 'dddd'),
+                                         ('Hello', 'Xxxxx')])
+def test_shape(word, shape):
+    t = Token(0, word, 10, 100)
+
+    assert t.shape == shape


### PR DESCRIPTION
* Added `is_digit`, `is_punct` and `shape` attributes following [SpaCy counterparts](https://spacy.io/api/token)
* `is_punct` checks based on the puncts used in word tokenizer helper functions.
* `shape` returns the word with each alphabetic character replaced by `x` or `X`  and numeric by `d`.
* More attributes should follow depending on the base class.