### PR TITLE
Add alternative IDF function to Token class attributes. [resolves #94]

### DIFF
--- a/sadedegel/bblock/token.py
+++ b/sadedegel/bblock/token.py
@@ -93,7 +93,7 @@ class Token:
         return log(Token._vocabulary.document_count / (1 + self.df)) + 1
 
     def prob_idf(self):
-        return log((Token.vocabulary.document_count - self.df) / self.df)
+        return log((Token._vocabulary.document_count - self.df) / self.df)
 
     @property
     def idf(self):

--- a/tests/context.py
+++ b/tests/context.py
@@ -14,4 +14,4 @@ from sadedegel.ml import create_model, load_model, save_model  # noqa # pylint: 
 from sadedegel.metrics import rouge1_score # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.server.__main__ import app # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import  tokenizer_context # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.config import get_all_configs, describe_config # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.config import get_all_configs, describe_config, idf_context, set_config # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,3 +15,13 @@ def test_describe_config_print(capsys):
 
     assert 'Change the default word tokenizer used by sadedegel' in captured.out or \
            'Change the default word tokenizer used by sadedegel' in captured.err
+
+
+def test_describe_idf_config_print(capsys):
+    describe_config('idf', True)
+    captured = capsys.readouterr()
+
+    assert 'Change default idf function used by sadedegel' \
+           '\n\nValid values are\nsmooth\nprobabilistic\n' in captured.out or \
+           'Change default idf function used by sadedegel' \
+           '\n\nValid values are\nsmooth\nprobabilistic\n' in captured.err

--- a/tests/test_token_attr.py
+++ b/tests/test_token_attr.py
@@ -1,5 +1,7 @@
+from math import ceil
 import pytest
-from .context import Token
+from pytest import raises
+from .context import Token, idf_context, set_config
 
 famous_quote = "Merhaba dünya. 36 ışıkyılı uzaktan geldik."
 
@@ -20,3 +22,17 @@ def test_shape(word, shape):
     t = Token(word)
 
     assert t.shape == shape
+
+
+@pytest.mark.parametrize('idf_type, idf', [('smooth', 6),
+                                           ('probabilistic', 5)])
+def test_idf(idf_type, idf):
+    with idf_context(idf_type):
+        t = Token('merhaba')
+        assert t.idf_type == idf_type
+        assert ceil(t.idf) == idf
+
+
+def test_idf_setting():
+    with raises(Exception, match=r".*is not a valid value.*"):
+        set_config('idf', 'plain')


### PR DESCRIPTION
**`config.py`**
- Add `idf` and its valid values to `configs`.
- Add `idf` case to `get_config` and `set_config`
- Define a `idf_context` context manager for tests in order to revert back to default after setting and using alternatives.
- A global `config_context` will also come as an enhancement after getting done with TF enhancements.
- `set_config` had a `check_config` wrapper as a decorator. `check_value` decorator also checks for configs and word tokenizer `valid_values` are `None`.
- Change `check_config` to `check_value` decorator and make a quickfix for now just to check `idf` `valid_values` since `word_tokenizer`'s is already `None` and goes unchecked. There will be separate issue for this.

**`vocabulary.py`**
- Add `idf_type` as a class variable. Defaults to `smooth`.
- Add `set_idf_function` as a class method for the `set_config` to use with `idf` config.
- Add `prob_idf` method for probabilistic idf implementation.
- Add `get_idf_func` methos for selecting idf method from a dictionary based on `idf_type` class variable.
- `__init__` sets `self.f_idf` to above selection func.

**`tests`**

- `test_config.py`: Add test for `idf` config description.
- `test_token_attr.py`: Add tests for setting valid and invalid `idf` config values.