### PR TITLE
Add alternative TF implementations to Sentence [resolves #93]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -175,6 +175,11 @@ class Sentences:
         if tokenizer_name != Sentences.tokenizer.__name__:
             Sentences.tokenizer = WordTokenizer.factory(tokenizer_name)
 
+    @classmethod
+    def set_tf_function(cls, tf_type):
+        if tf_type != Sentences.tf_type:
+            Sentences.tf_type = tf_type
+
     @property
     def bert(self):
         return self._bert
@@ -251,10 +256,9 @@ class Sentences:
     def get_tf_func(self):
         tf_funcs = {'binary': self.binary_tf(),
                     'raw': self.raw_tf(),
-                    #'freq': self.freq_tf(),
-                    #'log_norm': self.log_norm_tf(),
-                    #'double_norm': self.double_norm_tf()
-        }
+                    'freq': self.freq_tf(),
+                    'log_norm': self.log_norm_tf(),
+                    'double_norm': self.double_norm_tf()}
         return tf_funcs[Sentences.tf_type]
 
     @property

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -176,7 +176,7 @@ class Sentences:
     def set_word_tokenizer(tokenizer_name):
         if tokenizer_name != Sentences.tokenizer.__name__:
             Sentences.tokenizer = WordTokenizer.factory(tokenizer_name)
-            Sentences.vocabulary = Token.set_vocabulary(Sentences.tokenizer) d
+            Sentences.vocabulary = Token.set_vocabulary(Sentences.tokenizer)
 
     @classmethod
     def set_tf_function(cls, tf_type):

--- a/tests/context.py
+++ b/tests/context.py
@@ -14,4 +14,4 @@ from sadedegel.ml import create_model, load_model, save_model  # noqa # pylint: 
 from sadedegel.metrics import rouge1_score # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.server.__main__ import app # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import  tokenizer_context # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.config import get_all_configs, describe_config # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.config import get_all_configs, describe_config, tf_context, set_config # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/summarizer/context.py
+++ b/tests/summarizer/context.py
@@ -10,3 +10,4 @@ from sadedegel.summarize import TextRank  # noqa # pylint: disable=unused-import
 from sadedegel.summarize import TFIDFSummarizer # noqa # pylint: disable=unused-import
 from sadedegel import Doc, set_config, tokenizer_context # noqa # pylint: disable=unused-import, wrong
 from sadedegel.bblock import BertTokenizer, SimpleTokenizer # noqa # pylint: disable=unused-import, wrong
+from sadedegel.config import tf_context # noqa # pylint: disable=unused-import, wrong

--- a/tests/summarizer/test_tfidf.py
+++ b/tests/summarizer/test_tfidf.py
@@ -1,8 +1,14 @@
-from .context import TFIDFSummarizer, Doc
+from .context import TFIDFSummarizer, Doc, tf_context
 import numpy as np
 import pytest
 
 
-def test_tfidf():
-    d = Doc("Onu hiç sevmedim. Bu iş çok zor.")
-    assert TFIDFSummarizer().predict(d.sents) == pytest.approx(np.array([0.63611803, 0.36388197]))
+@pytest.mark.parametrize("tf_type, result", [('binary', np.array([0.63611803, 0.36388197])),
+                                             ('raw', np.array([0.62492017, 0.37507983])),
+                                             ('freq', np.array([0.62492017, 0.37507983])),
+                                             ('log_norm', np.array([0.62933615, 0.37066385])),
+                                             ('double_norm', np.array([0.63216882, 0.36783118]))])
+def test_tfidf(tf_type, result):
+    with tf_context(tf_type):
+        d = Doc("Onu hiç sevmedim. Bu iş çok zor.")
+        assert TFIDFSummarizer().predict(d.sents) == pytest.approx(result)

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import pytest
 from pytest import raises
-from .context import Doc, BertTokenizer, SimpleTokenizer, tokenizer_context, Sentences
+from .context import Doc, BertTokenizer, SimpleTokenizer, tokenizer_context, Sentences, tf_context
 
 
 @pytest.mark.parametrize("tokenizer", [BertTokenizer.__name__, SimpleTokenizer.__name__])
@@ -30,16 +30,20 @@ def test_bert_embedding_generation(tokenizer):
             assert d.bert_embeddings.shape == (2, 768)
 
 
-def test_tfidf_embedding_generation():
-    d = Doc("Ali topu tut. Ömer ılık süt iç.")
-    assert d.tfidf_embeddings.shape == (2, Sentences.vocabulary.size)
+@pytest.mark.parametrize('tf_type', ['binary', 'raw', 'freq', 'log_norm', 'double_norm'])
+def test_tfidf_embedding_generation(tf_type):
+    with tf_context(tf_type):
+        d = Doc("Ali topu tut. Ömer ılık süt iç.")
+        assert d.tfidf_embeddings.shape == (2, Sentences.vocabulary.size)
 
 
-def test_tfidf_compare_doc_and_sent():
-    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+@pytest.mark.parametrize('tf_type', ['binary', 'raw', 'freq', 'log_norm', 'double_norm'])
+def test_tfidf_compare_doc_and_sent(tf_type):
+    with tf_context(tf_type):
+        d = Doc("Ali topu tut. Ömer ılık süt iç.")
 
-    for i, sent in enumerate(d.sents):
-        assert np.all(np.isclose(d.tfidf_embeddings.toarray()[i, :], sent.tfidf()))
+        for i, sent in enumerate(d.sents):
+            assert np.all(np.isclose(d.tfidf_embeddings.toarray()[i, :], sent.tfidf()))
 
 
 testdata = [(True, True),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
-from .context import get_all_configs, describe_config
+from pytest import raises
+from .context import get_all_configs, describe_config, set_config
 
 
 def test_all_configs():
@@ -15,3 +16,18 @@ def test_describe_config_print(capsys):
 
     assert 'Change the default word tokenizer used by sadedegel' in captured.out or \
            'Change the default word tokenizer used by sadedegel' in captured.err
+
+
+def test_describe_tf_config_print(capsys):
+    describe_config('tf', True)
+    captured = capsys.readouterr()
+
+    assert 'Change default tf function used by sadedegel' \
+           '\n\nValid values are\nbinary\nraw\nfreq\nlog_norm\ndouble_norm\n' in captured.out or \
+           'Change default tf function used by sadedegel' \
+           '\n\nValid values are\nbinary\nraw\nfreq\nlog_norm\ndouble_norm\n' in captured.err
+
+
+def test_tf_setting():
+    with raises(Exception, match=r".*is not a valid value.*"):
+        set_config('tf', 'double_norm_k')


### PR DESCRIPTION
* Add `raw_count`, `term frequency`, `log normalization`, `double normalization 0.5` from [tf-idf](https://en.wikipedia.org/wiki/Tf%E2%80%93idf#:~:text=In%20information%20retrieval%2C%20tf%E2%80%93idf,in%20a%20collection%20or%20corpus.)
* Tests will come to finalize draft, full description of changes will be available by then.
* Default `tf_type` is `binary`. 