### PR TITLE
Feature/doc seq: Sequence-methods for Doc object

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -1,5 +1,6 @@
 import re
 from typing import List, Union
+import warnings
 
 import torch
 
@@ -248,7 +249,7 @@ class Doc:
 
         self.raw = raw
         self._bert = None
-        self.sents = []
+        self._sents = []
         self.spans = None
 
         if raw is not None:
@@ -263,11 +264,16 @@ class Doc:
             if len(eos_list) > 0:
                 for i, eos in enumerate(eos_list):
                     if i == 0:
-                        self.sents.append(Sentences(i, self.raw[:eos].strip(), self))
+                        self._sents.append(Sentences(i, self.raw[:eos].strip(), self))
                     else:
-                        self.sents.append(Sentences(i, self.raw[eos_list[i - 1] + 1:eos].strip(), self))
+                        self._sents.append(Sentences(i, self.raw[eos_list[i - 1] + 1:eos].strip(), self))
             else:
-                self.sents.append(Sentences(0, self.raw.strip(), self))
+                self._sents.append(Sentences(0, self.raw.strip(), self))
+
+    @property
+    def sents(self):
+        warnings.warn("Access to 'sents' attribute is deprecated. Index Doc object directly.", DeprecationWarning, stacklevel=2)
+        return self._sents
 
     @classmethod
     def from_sentences(cls, sentences: List[str]):
@@ -275,11 +281,12 @@ class Doc:
         d = Doc(None)
 
         for i, s in enumerate(sentences):
-            d.sents.append(Sentences(i, s, d))
+            d._sents.append(Sentences(i, s, d))
 
         d.raw = "\n".join(sentences)
 
         return d
+
 
     def __str__(self):
         return self.raw
@@ -288,11 +295,11 @@ class Doc:
         return self.raw
 
     def __len__(self):
-        return len(self.sents)
+        return len(self._sents)
 
     def max_length(self):
         """Maximum length of a sentence including special symbols."""
-        return max(len(s.tokens_with_special_symbols) for s in self.sents)
+        return max(len(s.tokens_with_special_symbols) for s in self._sents)
 
     def padded_matrix(self, return_numpy=False, return_mask=True):
         """Returns a 0 padded numpy.array or torch.tensor
@@ -306,14 +313,14 @@ class Doc:
         max_len = self.max_length()
 
         if not return_numpy:
-            mat = torch.tensor([pad(s.input_ids, max_len) for s in self.sents])
+            mat = torch.tensor([pad(s.input_ids, max_len) for s in self._sents])
 
             if return_mask:
                 return mat, (mat > 0).to(int)
             else:
                 return mat
         else:
-            mat = np.array([pad(s.input_ids, max_len) for s in self.sents])
+            mat = np.array([pad(s.input_ids, max_len) for s in self._sents])
 
             if return_mask:
                 return mat, (mat > 0).astype(int)

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -197,7 +197,7 @@ class Sentences:
 
     def rouge1(self, metric):
         return rouge1_score(
-            flatten([[tr_lower(token) for token in sent.tokens] for sent in self.document.sents if sent.id != self.id]),
+            flatten([[tr_lower(token) for token in sent.tokens] for sent in self.document if sent.id != self.id]),
             [tr_lower(t) for t in self.tokens], metric)
 
     def tfidf(self):
@@ -287,6 +287,11 @@ class Doc:
 
         return d
 
+    def __getitem__(self, sent_idx):
+        return self._sents[sent_idx]
+
+    def __iter__(self):
+        yield from self._sents
 
     def __str__(self):
         return self.raw

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -84,3 +84,19 @@ def test_doc_with_no_sentence():
 
     assert d.sents[0].tokens == Doc.from_sentences([("söz konusu adreste bulunan yolda yağmurdan "
                                                      "dolayı çamur ve toprak bulunmaktadır")]).sents[0].tokens
+
+def test_doc_index():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+
+    assert d[0] == "Ali topu tut."
+
+def test_doc_iter():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+
+    assert next(iter(d)) == "Ali topu tut."
+
+def test_doc_iter2():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    
+    for i,sentence in enumerate(d):
+        assert d._sents[i] == sentence


### PR DESCRIPTION
Implemented `__iter__` and `__getitem__` for Doc object and a DeprecationWarning for when Doc.sents is being accessed.

**TODO:**  Update tests to use Doc object directly instead of accessing .sents to prevent unnecessary noise in test output.

Solves: #117, #115 