### PR TITLE
Add valid values of word tokenizer to config [Resolves #109]

### DIFF
--- a/sadedegel/config.py
+++ b/sadedegel/config.py
@@ -12,7 +12,7 @@ Configuration = namedtuple("Configuration", "config, description, valid_values")
 configs = {
     "word_tokenizer": Configuration(config="word_tokenizer",
                                     description="Change the default word tokenizer used by sadedegel",
-                                    valid_values=None)
+                                    valid_values=['bert', 'simple'])
 }
 
 
@@ -21,7 +21,7 @@ def check_config(f):
     def wrapper(*args, **kwds):
         config = args[0]
         if config not in configs:
-            raise Exception((f"{config} is not a valid configuration for sadegel."
+            raise Exception((f"{config} is not a valid configuration for sadedegel."
                              "Use sadedegel.get_all_configs() to access list of valid configurations."))
         return f(*args, **kwds)
 
@@ -35,11 +35,15 @@ def check_value(f):
         cfg = configs.get(config, None)
 
         if cfg:
+            # Normalize User Inputs Based on Config Name
+            if cfg.config == 'word_tokenizer':
+                value = value.lower().replace(' ', '').replace('-', '').replace('tokenizer', '')
+
             if value not in cfg.valid_values:
                 raise Exception(
                     f"{value} is not a valid value for {config}. Choose one of {', '.join(cfg.valid_values)}")
         else:
-            raise Exception((f"{config} is not a valid configuration for sadegel."
+            raise Exception((f"{config} is not a valid configuration for sadedegel."
                              "Use sadedegel.get_all_configs() to access list of valid configurations."))
 
         return f(*args, **kwds)
@@ -47,7 +51,7 @@ def check_value(f):
     return wrapper
 
 
-@check_config
+@check_value
 def set_config(config: str, value: Any):
     if config == "word_tokenizer":
         Sentences.set_word_tokenizer(value)


### PR DESCRIPTION
**`config.py`**
- Add `bert` and `simple` to valid_values in `configs`.
- Make sure `check_values` decorator normalizes user input for `word_tokenizers.`
- This normalization step can/should also be implemented for other configs to come. (`tf_type`, `tf_function` normalizes to `tf`)
- Use `check_value` decorator on top of `set_config`. It checks both for config names and its respective valid_values.
- I am aware `word_tokenizer` factory checks valid values when new config is set; but other configs will come such as tf, idf that are selected among functions instead implemented as abstract class (I might work on it too if needed). 
- So I suggest we do checks on the config level s.t. only modules will reach `config` when needed, `config` will not access the modules to get current values as @askarbozcan stated.  
- Current changes do not break any tests.