### PR TITLE
Add document level tfidf embedding [resolves #128]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -292,6 +292,30 @@ class Doc:
 
         return d
 
+    @property
+    def tf(self):
+        v = np.zeros(len(Token.vocabulary))
+
+        for sent in iter(self):
+            for token in sent.tokens:
+                t = Token(token)
+                if not t.is_oov:
+                    v[t.id] = 1
+
+        return v
+
+    @property
+    def idf(self):
+        v = np.zeros(len(Token.vocabulary))
+
+        for sent in iter(self):
+            for token in sent.tokens:
+                t = Token(token)
+                if not t.is_oov:
+                    v[t.id] = t.idf
+
+        return v
+
     def __getitem__(self, sent_idx):
         return self._sents[sent_idx]
 
@@ -375,3 +399,8 @@ class Doc:
         m = csr_matrix((data, indices, indptr), dtype=np.float32, shape=(len(self), len(Token.vocabulary)))
 
         return m
+
+    @property
+    def tfidf_doc_embedding(self):
+        v = self.tf * self.idf
+        return csr_matrix(v)

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -298,7 +298,7 @@ class Doc:
 
     @property
     def tf(self):
-        v = np.zeros(len(Token.vocabulary))
+        v = np.zeros(len(Token.vocabulary()))
 
         for sent in iter(self):
             for token in sent.tokens:
@@ -310,7 +310,7 @@ class Doc:
 
     @property
     def idf(self):
-        v = np.zeros(len(Token.vocabulary))
+        v = np.zeros(len(Token.vocabulary()))
 
         for sent in iter(self):
             for token in sent.tokens:

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import pytest
 from pytest import raises
+from scipy.sparse import isspmatrix_csr
 from .context import Doc, BertTokenizer, SimpleTokenizer, tokenizer_context, Token
 
 
@@ -117,3 +118,18 @@ def test_doc_iter_eq():
 
     for i, sentence in enumerate(d):
         assert d._sents[i] == sentence == d[i]
+
+
+def test_doc_level_tfidf():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    assert d.tfidf_doc_embedding.shape == (1, Token.vocabulary.size)
+
+
+def test_doc_level_tf_idf_value():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    assert np.sum(d.tfidf_doc_embedding.toarray()) == pytest.approx(31.938)
+
+
+def test_doc_level_tf_idf_type():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    assert isspmatrix_csr(d.tfidf_doc_embedding)

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -122,7 +122,7 @@ def test_doc_iter_eq():
 
 def test_doc_level_tfidf():
     d = Doc("Ali topu tut. Ömer ılık süt iç.")
-    assert d.tfidf_doc_embedding.shape == (1, Token.vocabulary.size)
+    assert d.tfidf_doc_embedding.shape == (1, Token.vocabulary().size)
 
 
 def test_doc_level_tf_idf_value():


### PR DESCRIPTION
- Add `tfidf` function to `Doc` object as `tfidf_doc_embeddings`
- Calculate tf and idf of Tokens iterating over Doc instance's sentences without using `.sents` .
- Return embedding in sparse format.

**Future:**
- Revisit naming convention:
       -  `tfidf_embeddings` will return sentence level embeddings.
       - `tfidf_embedding` will return document level embedding.
- Implement other tf functions based on feedback for PR of `feature/alternative_tf` branch. #110 