### PR TITLE
Tokenization Dataset download.

### DIFF
--- a/sadedegel/dataset/tokenization/__init__.py
+++ b/sadedegel/dataset/tokenization/__init__.py
@@ -1,0 +1,3 @@
+from ._core import check_and_display
+from .raw import _desc
+from .tokenized import _desc

--- a/sadedegel/dataset/tokenization/__init__.py
+++ b/sadedegel/dataset/tokenization/__init__.py
@@ -1,3 +1,3 @@
-from ._core import check_and_display
+from ._core import check_and_display, tok_eval
 from .raw import _desc
 from .tokenized import _desc

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -6,6 +6,8 @@ import boto3
 from smart_open import open
 import tarfile
 
+from ._core import check_and_display
+
 
 @click.group(help="Tokenization Dataset Commandline.")
 def cli():
@@ -20,6 +22,8 @@ def cli():
 @click.option("--data_home", '-d', help="Data home directory", default="~/.sadedegel_data")
 def download(access_key, secret_key, data_home):
     """Download tokenization corpus from cloud with your key."""
+
+
 
     data_home = Path(os.path.expanduser(data_home)) / 'tokenization'
     logger.info(f"Data directory for tokenization data {data_home}")
@@ -44,9 +48,15 @@ def download(access_key, secret_key, data_home):
         with open(url, 'rb', transport_params=transport_params) as fp:
             tf = tarfile.open(fileobj=fp)
 
-            tf.extractall(data_home.absolute())
+            extract_to = (Path(os.path.expanduser(data_home)) / tarball.split('/')[0])
+
+            tf.extractall(extract_to.absolute())
 
         click.secho(f".done: {tarball}", fg="green")
+
+    d = check_and_display('~/.sadedegel_data')
+    click.secho("Checking download...")
+    click.secho("Dataset stats: " + click.style(f"{d}", fg="yellow"), color='white')
 
 
 if __name__ == "__main__":

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -1,0 +1,61 @@
+import click
+import os.path
+from loguru import logger
+from pathlib import Path
+import boto3
+from smart_open import open
+import tarfile
+import glob
+from tqdm import tqdm
+from sadedegel.tokenize import Doc
+import json
+import sys
+
+# from ..util import safe_read
+
+
+@click.group(help="Tokenization Dataset Commandline.")
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--access-key", help="Access Key ID to download dataset.", prompt=True,
+              default=lambda: os.environ.get('sadedegel_access_key', ''))
+@click.option("--secret-key", help="Secret Key ID to download dataset.", prompt=True,
+              default=lambda: os.environ.get('sadedegel_secret_key', ''))
+@click.option("--data_home", '-d', help="Data home directory", default="~/.sadedegel_data")
+def download(access_key, secret_key, data_home):
+    """Download tokenization corpus from cloud with your key."""
+
+    data_home = Path(os.path.expanduser(data_home)) / 'tokenization'
+    logger.info(f"Data directory for tokenization data {data_home}")
+
+    data_home.mkdir(parents=True, exist_ok=True)
+
+
+    transport_params = {
+        'session': boto3.Session(aws_access_key_id=access_key,
+                                 aws_secret_access_key=secret_key),
+        'resource_kwargs': {
+            'endpoint_url': 'https://storage.googleapis.com',
+        }
+    }
+
+    __tarballs__ = ['raw/80M_raw.tar.gz', 'tokenized/80M_tokenized.tar.gz']
+
+    click.echo(click.style(f"\nStarting Download...", fg="yellow"))
+
+    for tarball in __tarballs__:
+        url = f"s3://sadedegel/dataset/tokenization/{tarball}"
+
+        with open(url, 'rb', transport_params=transport_params) as fp:
+            tf = tarfile.open(fileobj=fp)
+
+            tf.extractall(data_home.absolute())
+
+        click.secho(f".done: {tarball}", fg="green")
+
+
+if __name__ == "__main__":
+    cli()

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -5,13 +5,6 @@ from pathlib import Path
 import boto3
 from smart_open import open
 import tarfile
-import glob
-from tqdm import tqdm
-from sadedegel.tokenize import Doc
-import json
-import sys
-
-# from ..util import safe_read
 
 
 @click.group(help="Tokenization Dataset Commandline.")
@@ -32,7 +25,6 @@ def download(access_key, secret_key, data_home):
     logger.info(f"Data directory for tokenization data {data_home}")
 
     data_home.mkdir(parents=True, exist_ok=True)
-
 
     transport_params = {
         'session': boto3.Session(aws_access_key_id=access_key,

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -111,7 +111,7 @@ def prepare(data_home, data_version):
     click.secho("Saving " + click.style("Tokenized .json file.", fg='blue'))
     with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / data_version / "tokenized" / "Tokenized.json"),
               'w') as j:
-        json.dump(documents, j)
+        json.dump(tokens, j)
 
 
 if __name__ == "__main__":

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -3,6 +3,9 @@ import os.path
 from loguru import logger
 from pathlib import Path
 import boto3
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+import json
 from smart_open import open
 import tarfile
 
@@ -56,6 +59,59 @@ def download(access_key, secret_key, data_home, data_version):
     d = check_and_display('~/.sadedegel_data')
     click.secho("Checking download...")
     click.secho("Dataset stats: " + click.style(f"{d}", fg="yellow"), color='white')
+
+
+@cli.command()
+@click.option("--data_home", '-d', help="Data home directory", default="~/.sadedegel_data")
+@click.option('--data-version', "-v", help="Dataset version", default="v2")
+def prepare(data_home, data_version):
+
+    __txts__ = ["Raw_Text_80M_Portion_of_TimeLine.txt",
+                "Tokenized_Text_80M_Portion_of_TimeLine.txt"]
+
+    click.secho("Reading "+click.style("Raw .txt file.", fg='blue'))
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / data_version / "raw" / __txts__[0]), 'r') as f:
+        raw = ''.join(f.readlines())
+    f.close()
+
+    click.secho("Parsing "+click.style("Raw data.", fg='blue'))
+    soup = BeautifulSoup(raw, 'html.parser')
+    documents = []
+    for link in tqdm(soup.find_all('text')):
+        d = {
+            'index': int(link.get('document').split('_')[-1]) - 1000,
+            'doc_id': link.get('document'),
+            'category': link.get('category'),
+            'text': link.get_text()[1:-1]
+        }
+        documents.append(d)
+
+    click.secho("Saving " + click.style("Raw .json file.", fg='blue'))
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / data_version / "raw" / "Raw.json"), 'w') as j:
+        json.dump(documents, j)
+
+    click.secho("Reading " + click.style("Tokenized .txt file.", fg='blue'))
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / data_version / "tokenized" / __txts__[1]),
+              'r') as f:
+        tok = ''.join(f.readlines())
+    f.close()
+
+    click.secho("Parsing " + click.style("Tokenized data.", fg='blue'))
+    soup2 = BeautifulSoup(tok, 'html.parser')
+    tokens = []
+    for link in tqdm(soup2.find_all('text')):
+        d = {
+            'index': int(link.get('document').split('_')[-1]) - 1000,
+            'doc_id': link.get('document'),
+            'category': link.get('category'),
+            'tokens': link.get_text().split('\n')[1:-1]
+        }
+        tokens.append(d)
+
+    click.secho("Saving " + click.style("Tokenized .json file.", fg='blue'))
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / data_version / "tokenized" / "Tokenized.json"),
+              'w') as j:
+        json.dump(documents, j)
 
 
 if __name__ == "__main__":

--- a/sadedegel/dataset/tokenization/__main__.py
+++ b/sadedegel/dataset/tokenization/__main__.py
@@ -20,10 +20,9 @@ def cli():
 @click.option("--secret-key", help="Secret Key ID to download dataset.", prompt=True,
               default=lambda: os.environ.get('sadedegel_secret_key', ''))
 @click.option("--data_home", '-d', help="Data home directory", default="~/.sadedegel_data")
-def download(access_key, secret_key, data_home):
+@click.option("--data-version", "-v", help="Dataset version", default="v2")
+def download(access_key, secret_key, data_home, data_version):
     """Download tokenization corpus from cloud with your key."""
-
-
 
     data_home = Path(os.path.expanduser(data_home)) / 'tokenization'
     logger.info(f"Data directory for tokenization data {data_home}")
@@ -43,12 +42,12 @@ def download(access_key, secret_key, data_home):
     click.echo(click.style(f"\nStarting Download...", fg="yellow"))
 
     for tarball in __tarballs__:
-        url = f"s3://sadedegel/dataset/tokenization/{tarball}"
+        url = f"s3://sadedegel/dataset/tokenization/{data_version}/{tarball}"
 
         with open(url, 'rb', transport_params=transport_params) as fp:
             tf = tarfile.open(fileobj=fp)
 
-            extract_to = (Path(os.path.expanduser(data_home)) / tarball.split('/')[0])
+            extract_to = (Path(os.path.expanduser(data_home)) / data_version / tarball.split('/')[0])
 
             tf.extractall(extract_to.absolute())
 

--- a/sadedegel/dataset/tokenization/_core.py
+++ b/sadedegel/dataset/tokenization/_core.py
@@ -2,6 +2,13 @@ from os.path import expanduser, getsize
 from pathlib import Path
 import glob
 import click
+import numpy as np
+import time
+
+from sadedegel.config import tokenizer_context
+from sadedegel import Doc
+from tabulate import tabulate
+
 
 __general_download_message__ = """Ensure that you have properly downloaded extended or tokenization corpus using
 
@@ -23,6 +30,15 @@ __tokenization_download_message__ = """Ensure that you have properly downloaded 
         """
 
 __tokenization_version_message__ = "Ensure your dataset is in versioned format."
+
+
+def dot_progress(i, length, t0):
+    n = np.ceil(length * 0.05)
+
+    if i == length - 1:
+        click.echo(f". {(time.time() - t0):.2f} sec", nl=True, color="yellow")
+    elif i % n == 0 and i != 0:
+        click.echo(".", nl=False, color="yellow")
 
 
 def check_directory_structure(path: str, version) -> bool:
@@ -76,3 +92,55 @@ def check_and_display(data_home: str, version='v2'):
     if check_directory_structure(data_home, version):
         return dict(byte=dict(raw=raw_stats(data_home, version) / 1e6,
                               tokens=tokenized_stats(data_home, version) / 1e6))
+
+
+def tok_eval(raw_docs, tokenized_docs, tokenizers=['simple', 'bert']):
+    """Evaluate tokenizers on a downsized version of tokenization dataset.
+
+    :param raw_docs: Raw documents of tokenization corpus.
+    :type raw_docs: dict
+    :param tokenized_docs: Tokenized documents of tokenization corpus.
+    :type tokenized_docs: dict
+    :param tokenizers: List of tokenizer names to evaluate. Defaults to ["simple", "bert"].
+    :type tokenizers: List[str]
+
+    :return: IoU score between list of true tokens and list of tokenized tokens.
+    """
+    scores = {}
+    for tokenizer in tokenizers:
+        t0 = time.time()
+        with tokenizer_context(tokenizer):
+            click.echo("Word Tokenizer: " + click.style(f"{tokenizer}", fg="blue"), nl=False)
+
+            ious = []
+            for i, (raw_doc, tokenized_doc) in enumerate(zip(raw_docs, tokenized_docs)):
+
+                true_tokens = set(tokenized_doc['tokens'])
+
+                d = Doc(raw_doc['text'])
+                tokens = [token for sentence in d for token in sentence.tokens]
+
+                if tokenizer == 'bert':
+                    fixed_hashtags = []
+                    for tok in tokens:
+                        if "##" not in tok:
+                            fixed_hashtags.append(tok)
+                        else:
+                            merged = fixed_hashtags[-1] + tok.split("##")[1]
+                            fixed_hashtags.pop(-1)
+                            fixed_hashtags.append(merged)
+                    tokens = fixed_hashtags
+
+                pred_tokens = set(tokens)
+
+                union = len(true_tokens.union(pred_tokens))
+                intersection = len(true_tokens.intersection(pred_tokens))
+
+                ious.append(intersection/union)
+
+                dot_progress(i, len(raw_docs), t0)
+            scores[tokenizer] = np.mean(ious)
+
+    table = [[item[0], item[1]] for item in scores.items()]
+
+    return table

--- a/sadedegel/dataset/tokenization/_core.py
+++ b/sadedegel/dataset/tokenization/_core.py
@@ -74,5 +74,5 @@ def tokenized_stats(data_home: str, version) -> int:
 
 def check_and_display(data_home: str, version='v2'):
     if check_directory_structure(data_home, version):
-        return dict(byte=dict(raw=f"{raw_stats(data_home, version) / 1e6} MB",
-                              tokens=f"{tokenized_stats(data_home, version) / 1e6} MB"))
+        return dict(byte=dict(raw=raw_stats(data_home, version) / 1e6,
+                              tokens=tokenized_stats(data_home, version) / 1e6))

--- a/sadedegel/dataset/tokenization/_core.py
+++ b/sadedegel/dataset/tokenization/_core.py
@@ -22,8 +22,10 @@ __tokenization_download_message__ = """Ensure that you have properly downloaded 
 
         """
 
+__tokenization_version_message__ = "Ensure your dataset is in versioned format."
 
-def check_directory_structure(path: str) -> bool:
+
+def check_directory_structure(path: str, version) -> bool:
     if not Path(expanduser(path)).exists():
         click.secho(f"{path} not found.\n", fg="red")
         click.secho(__general_download_message__, fg="red")
@@ -36,12 +38,18 @@ def check_directory_structure(path: str) -> bool:
 
         return False
 
-    elif not (Path(expanduser(path)) / "tokenization" / "raw").exists():
+    elif not(Path(expanduser(path)) / "tokenization" / version).exists():
+        click.secho(f"Stated version is not found.\n", fg="red")
+        click.secho(__tokenization_version_message__, fg="red")
+
+        return False
+
+    elif not (Path(expanduser(path)) / "tokenization" / version / "raw").exists():
         click.secho(f"Tokenization Raw Dataset not found.\n", fg="red")
 
         return False
 
-    elif not (Path(expanduser(path)) / "tokenization" / "tokenized").exists():
+    elif not (Path(expanduser(path)) / "tokenization" / version / "tokenized").exists():
         click.secho(f"Tokenization Tokenized Dataset not found.\n", fg="red")
 
         return False
@@ -50,21 +58,21 @@ def check_directory_structure(path: str) -> bool:
         return True
 
 
-def raw_stats(data_home: str) -> int:
+def raw_stats(data_home: str, version) -> int:
     sz = 0
-    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / "raw" / "*.txt").absolute())):
+    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / version / "raw" / "*.txt").absolute())):
         sz += getsize(f)
     return sz
 
 
-def tokenized_stats(data_home: str) -> int:
+def tokenized_stats(data_home: str, version) -> int:
     sz = 0
-    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / "tokenized" / "*.txt").absolute())):
+    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / version / "tokenized" / "*.txt").absolute())):
         sz += getsize(f)
     return sz
 
 
-def check_and_display(data_home: str):
-    if check_directory_structure(data_home):
-        return dict(byte=dict(raw=f"{raw_stats(data_home) / 1e6} MB",
-                              tokens=f"{tokenized_stats(data_home) / 1e6} MB"))
+def check_and_display(data_home: str, version='v2'):
+    if check_directory_structure(data_home, version):
+        return dict(byte=dict(raw=f"{raw_stats(data_home, version) / 1e6} MB",
+                              tokens=f"{tokenized_stats(data_home, version) / 1e6} MB"))

--- a/sadedegel/dataset/tokenization/_core.py
+++ b/sadedegel/dataset/tokenization/_core.py
@@ -1,0 +1,70 @@
+from os.path import expanduser, getsize
+from pathlib import Path
+import glob
+import click
+
+__general_download_message__ = """Ensure that you have properly downloaded extended or tokenization corpus using
+
+            python -m sadedegel.dataset.extended download --access-key xxx --secret-key xxxx
+            python -m sadedegel.dataset.tokenization download --access-key xxx --secret-key xxxx
+
+        Unfortunately due to data licensing issues we could not share data publicly. 
+        Get in touch with sadedegel team to obtain a download key.
+
+        """
+
+__tokenization_download_message__ = """Ensure that you have properly downloaded tokenization corpus using
+
+            python -m sadedegel.dataset.tokenization download --access-key xxx --secret-key xxxx
+
+        Unfortunately due to data licensing issues we could not share data publicly. 
+        Get in touch with sadedegel team to obtain a download key.
+
+        """
+
+
+def check_directory_structure(path: str) -> bool:
+    if not Path(expanduser(path)).exists():
+        click.secho(f"{path} not found.\n", fg="red")
+        click.secho(__general_download_message__, fg="red")
+
+        return False
+
+    elif not (Path(expanduser(path)) / "tokenization").exists():
+        click.secho(f"Tokenization Dataset not found.\n", fg="red")
+        click.secho(__tokenization_download_message__, fg="red")
+
+        return False
+
+    elif not (Path(expanduser(path)) / "tokenization" / "raw").exists():
+        click.secho(f"Tokenization Raw Dataset not found.\n", fg="red")
+
+        return False
+
+    elif not (Path(expanduser(path)) / "tokenization" / "tokenized").exists():
+        click.secho(f"Tokenization Tokenized Dataset not found.\n", fg="red")
+
+        return False
+
+    else:
+        return True
+
+
+def raw_stats(data_home: str) -> int:
+    sz = 0
+    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / "raw" / "*.txt").absolute())):
+        sz += getsize(f)
+    return sz
+
+
+def tokenized_stats(data_home: str) -> int:
+    sz = 0
+    for f in glob.glob(str((Path(expanduser(data_home)) / "tokenization" / "tokenized" / "*.txt").absolute())):
+        sz += getsize(f)
+    return sz
+
+
+def check_and_display(data_home: str):
+    if check_directory_structure(data_home):
+        return dict(byte=dict(raw=f"{raw_stats(data_home) / 1e6} MB",
+                              tokens=f"{tokenized_stats(data_home) / 1e6} MB"))

--- a/sadedegel/dataset/tokenization/raw/__init__.py
+++ b/sadedegel/dataset/tokenization/raw/__init__.py
@@ -1,1 +1,1 @@
-from ._core import load_corpus
+from ._core import load_corpus, _desc

--- a/sadedegel/dataset/tokenization/raw/__init__.py
+++ b/sadedegel/dataset/tokenization/raw/__init__.py
@@ -1,0 +1,1 @@
+from ._core import load_corpus

--- a/sadedegel/dataset/tokenization/raw/_core.py
+++ b/sadedegel/dataset/tokenization/raw/_core.py
@@ -1,0 +1,25 @@
+import json
+import os
+from pathlib import Path
+
+
+def load_corpus(return_iter=True, version='v2', data_home='~/.sadedegel_data'):
+    """Load raw tokenization corpus.
+
+    :param return_iter: Returns iter[dict] if True List[dict] else, defaults to True
+    :type return_iter: bool
+    :param version: version of tokenization dataset, defaults to 'v2'
+    :type version: str
+    :param data_home:
+
+    :returns: Iterator or List of dicts containing raw document, doc_id, index and document category if available.
+    :rtype: Iter[dict] or List[dict]
+    """
+
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / version / "raw" / "Raw.json")) as j:
+        raw = json.load(j)
+
+    if return_iter:
+        return iter(raw)
+    else:
+        return raw

--- a/sadedegel/dataset/tokenization/raw/_core.py
+++ b/sadedegel/dataset/tokenization/raw/_core.py
@@ -3,6 +3,9 @@ import os
 from pathlib import Path
 
 
+_desc = "Tokenization Raw Corpus"
+
+
 def load_corpus(return_iter=True, version='v2', data_home='~/.sadedegel_data'):
     """Load raw tokenization corpus.
 

--- a/sadedegel/dataset/tokenization/tokenized/__init__.py
+++ b/sadedegel/dataset/tokenization/tokenized/__init__.py
@@ -1,1 +1,1 @@
-from ._core import load_corpus
+from ._core import load_corpus, _desc

--- a/sadedegel/dataset/tokenization/tokenized/__init__.py
+++ b/sadedegel/dataset/tokenization/tokenized/__init__.py
@@ -1,0 +1,1 @@
+from ._core import load_corpus

--- a/sadedegel/dataset/tokenization/tokenized/_core.py
+++ b/sadedegel/dataset/tokenization/tokenized/_core.py
@@ -1,0 +1,25 @@
+import json
+import os
+from pathlib import Path
+
+
+def load_corpus(return_iter=True, version='v2', data_home='~/.sadedegel_data'):
+    """Load tokenized tokenization corpus.
+
+    :param return_iter: Returns iter[dict] if True List[dict] else, defaults to True
+    :type return_iter: bool
+    :param version: version of tokenization dataset, defaults to 'v2'
+    :type version: str
+    :param data_home:
+
+    :returns: Iterator or List of dicts containing tokenized document, doc_id, index and document category if available.
+    :rtype: Iter[dict] or List[dict]
+    """
+
+    with open(str(Path(os.path.expanduser(data_home)) / 'tokenization' / version / "tokenized" / "Tokenized.json")) as j:
+        tok = json.load(j)
+
+    if return_iter:
+        return iter(tok)
+    else:
+        return tok

--- a/sadedegel/dataset/tokenization/tokenized/_core.py
+++ b/sadedegel/dataset/tokenization/tokenized/_core.py
@@ -3,6 +3,9 @@ import os
 from pathlib import Path
 
 
+_desc = "Tokenization Tokenized Corpus"
+
+
 def load_corpus(return_iter=True, version='v2', data_home='~/.sadedegel_data'):
     """Load tokenized tokenization corpus.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
     # Needed to silence warnings (and to be a worthwhile package)
     name='sadedegel',
     # Needed to actually package something
-    packages=['sadedegel', 'sadedegel.bblock', 'sadedegel.dataset', 'sadedegel.dataset.extended', 'sadedegel.summarize',
+    packages=['sadedegel', 'sadedegel.bblock', 'sadedegel.dataset', 'sadedegel.dataset.extended',
+              'sadedegel.dataset.tokenization',
+              'sadedegel.summarize',
               'sadedegel.tokenize', 'sadedegel.ml',
               'sadedegel.server', 'sadedegel.metrics'],
     package_data={
@@ -36,6 +38,7 @@ setup(
         sadedegel=sadedegel.__main__:cli
         sadedegel-dataset=sadedegel.dataset.__main__:cli
         sadedegel-dataset-extended=sadedegel.dataset.extended.__main__:cli
+        sadedegel-dataset-tokenization=sadedegel.dataset.tokenization.__main__:cli
         sadedegel-summarize=sadedegel.summarize.__main__:cli
         sadedegel-sbd=sadedegel.tokenize.__main__:cli
         sadedegel-server=sadedegel.server.__main__:server

--- a/tests/datasets/context.py
+++ b/tests/datasets/context.py
@@ -5,6 +5,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus, load_sentence_corpus,load_annotated_corpus, tokenization # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.extended import load_extended_metadata, load_extended_sents_corpus, load_extended_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.dataset.tokenization import check_and_display # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset.tokenization import check_and_display, tok_eval # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset import util # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset import file_paths, CorpusTypeEnum # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/datasets/context.py
+++ b/tests/datasets/context.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
-from sadedegel.dataset import load_raw_corpus, load_sentence_corpus,load_annotated_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset import load_raw_corpus, load_sentence_corpus,load_annotated_corpus, tokenization # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.extended import load_extended_metadata, load_extended_sents_corpus, load_extended_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset.tokenization import check_and_display # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset import util # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset import file_paths, CorpusTypeEnum # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/datasets/test_tokenization_corpus.py
+++ b/tests/datasets/test_tokenization_corpus.py
@@ -1,7 +1,8 @@
 import pytest
 from pathlib import Path
 from os.path import expanduser
-from .context import tokenization, check_and_display
+import numpy as np
+from .context import tokenization, check_and_display, tok_eval
 
 
 def test_submodule_import():
@@ -45,3 +46,19 @@ def test_corpus_size(loader, return_iter, expected_count):
 
     if not return_iter:
         assert len(docs) == expected_count
+
+
+def test_evaluator():
+    raw_docs = tokenization.raw.load_corpus()
+    tokenized_docs = tokenization.tokenized.load_corpus()
+    eval_raw, eval_tokenized = [], []
+    for raw_doc, tokenized_doc in zip(raw_docs, tokenized_docs):
+        ix = raw_doc['index']
+        if ix == 2:
+            break
+        eval_raw.append(raw_doc)
+        eval_tokenized.append(tokenized_doc)
+    table = tok_eval(eval_raw, eval_tokenized, ["simple", "bert"])
+
+    assert np.float16(table[0][1]) == np.float16(0.8315)
+    assert np.float16(table[1][1]) == np.float16(0.8739)

--- a/tests/datasets/test_tokenization_corpus.py
+++ b/tests/datasets/test_tokenization_corpus.py
@@ -1,0 +1,47 @@
+import pytest
+from pathlib import Path
+from os.path import expanduser
+from .context import tokenization, check_and_display
+
+
+def test_submodule_import():
+    assert 'Raw' in tokenization.raw._desc
+    assert 'Tokenized' in tokenization.tokenized._desc
+
+
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+def test_raw():
+    raw = tokenization.raw.load_corpus()
+
+    assert sum(1 for _ in raw) == 302936
+
+
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+def test_tokenized():
+    tokenized = tokenization.tokenized.load_corpus()
+
+    assert sum(1 for _ in tokenized) == 302936
+
+
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+def test_metadata():
+    stats = check_and_display("~/.sadedegel_data")
+
+    assert stats['byte']['raw'] * 1e6 >= 1 * 1024 * 1024
+    assert stats['byte']['raw'] * 1e6 >= 1 * 1024 * 1024
+
+
+corpus_parameters = [(tokenization.raw.load_corpus, True, 302936),
+                     (tokenization.raw.load_corpus, False, 302936),
+                     (tokenization.tokenized.load_corpus, True, 302936),
+                     (tokenization.tokenized.load_corpus, True, 302936)]
+
+
+@pytest.mark.parametrize("loader, return_iter, expected_count", corpus_parameters)
+def test_corpus_size(loader, return_iter, expected_count):
+    docs = loader(return_iter=return_iter)
+
+    assert sum(1 for _ in docs) == expected_count
+
+    if not return_iter:
+        assert len(docs) == expected_count


### PR DESCRIPTION
- Initial commit to establish tokenization dataset among other SadedeGel datasets.
- Raw and tokenized tarballs are available in GC Bucket. Acceseed via access and secret keys.
- Download command works in the same fashion as `sadedegel-dataset-extended download`. There is now `sadedegel-dataset-tokenization download`.
- Add relevant changes to `setup.py`
- Test download command.

**Future**
- Add necessary checks for dataset and file hiearrchy.
- Add versioning to hierarchy as other tokenization corpus can come.