### PR TITLE
Doc2Bert from Sentence Embeddings [resolves #137]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -416,3 +416,32 @@ class Doc:
 
     def tfidf(self):
         return self.tf.multiply(self.idf)
+
+    def doc2bert(self, compute="mean"):
+        """Computes BERT embedding for a document from the BERT embeddings of the sentence
+        objects the document consists of.
+
+        :param compute: Method to compute document embedding from sentence embeddings, defaults to `mean`.
+                        `mean` computes the mean of sentence embeddings to get document embedding.
+                        `rouge-weighted` computes the weighted mean of sentence embeddings using sentence Rouge1 scores
+                        as weights.
+                        `length-weighted` computes the weighted mean of sentence embeddings using sentence
+                        length as weights.
+        :type compute: str
+        :return: Document BERT Embedding.
+        :rtype: numpy.ndarray
+        """
+        if compute == "mean":
+            v = np.mean(self.bert_embeddings, axis=0)
+        elif compute == "rouge-weighted":
+            from sadedegel.summarize import Rouge1Summarizer
+            w = Rouge1Summarizer().predict(self).reshape(1, -1)
+            v = np.dot(w, self.bert_embeddings)
+        elif compute == "length-weighted":
+            from sadedegel.summarize import LengthSummarizer
+            w = LengthSummarizer().predict(self).reshape(1, -1)
+            v = np.dot(w, self.bert_embeddings)
+        else:
+            raise ValueError("Not a valid compute type.")
+
+        return v.reshape(-1)

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -133,3 +133,17 @@ def test_doc_level_tf_idf_value():
 def test_doc_level_tf_idf_type():
     d = Doc("Ali topu tut. Ömer ılık süt iç.")
     assert isspmatrix_csr(d.tfidf())
+
+
+@pytest.mark.parametrize('compute_type, shape', [("mean", (768,)),
+                                                 ("rouge-weighted", (768,)),
+                                                 ("length-weighted", (768,))])
+def test_doc2bert(compute_type, shape):
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    assert d.doc2bert(compute_type).shape == shape
+
+
+def test_doc2bert_valerr():
+    d = Doc("Ali topu tut. Ömer ılık süt iç.")
+    with pytest.raises(ValueError, match=r".*Not a valid compute type.*"):
+        d.doc2bert(compute="char-length-weighted")


### PR DESCRIPTION
**`sadedegel/bblock/doc.py`**
- Add `doc2bert` method to `Doc` object.
- Compute simple or weighted mean of sentence BERT embeddings based on `compute` param.
- Weighted calculations derive weights from sadedegel summarizers `Rouge1Summarizer` and `LengthSummarizer`.
- Add docstring in Sphinx format.

**`test/test_buildingblocks.py`**
- Test output embedding shape for all existing `compute` values.
- Test value error for non-existing `compute` value.