### PR TITLE
Add high level encode functionality for seamless embedding extraction from a text. [resolves #138]

### DIFF
--- a/sadedegel/__init__.py
+++ b/sadedegel/__init__.py
@@ -1,3 +1,4 @@
 from .bblock import Doc, Sentences  # noqa: F401
 from .bblock.token import Token  # noqa: F401
+from .bblock.encode import encode  # noqa: F401
 from .config import set_config, get_config, get_all_configs, describe_config, tokenizer_context  # noqa: F401

--- a/sadedegel/bblock/__init__.py
+++ b/sadedegel/bblock/__init__.py
@@ -1,2 +1,3 @@
 from .doc import Doc, Sentences
 from .word_tokenizer import BertTokenizer, SimpleTokenizer, WordTokenizer
+from .encode import encode

--- a/sadedegel/bblock/encode.py
+++ b/sadedegel/bblock/encode.py
@@ -1,0 +1,38 @@
+import numpy as np
+from scipy.sparse import csr_matrix
+from typing import Union
+from .doc import Doc
+
+
+def encode(document: str, embed='bert', level='sentence') -> Union[np.ndarray, csr_matrix]:
+    """High level function for users to encode sentences of given document in desired embedding strategy,
+    using SadedeGel building blocks.
+
+    :param document: Input document to be encoded.
+    :type document: str
+    :param embed: Type of embedding to encode the document's sentences into, defaults to `bert`.
+    :type document: str
+    :param level: Level of embedding. `sentence` level returns embeddings for each Sentence object in Doc.
+    `document` level returns signle embedding for the input document.
+    :type level: str
+
+    :return: Encoding
+    :rtype: numpy.ndarray, scipy.sparse.csr_matrix
+    """
+
+    d = Doc(document)
+
+    if embed == 'bert':
+        if level == 'sentence':
+            emb = d.bert_embeddings
+        elif level == 'document':
+            raise NotImplementedError("Doc2Bert is not in current release yet.")
+    elif embed == 'tfidf':
+        if level == 'sentence':
+            emb = d.tfidf_embeddings
+        elif level == 'document':
+            emb = d.tfidf()
+    else:
+        raise ValueError("Not a valid embedding type in SadedeGel. Valid values are {\"bert\", \"tfidf\"}")
+
+    return emb

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,7 +7,7 @@ from sadedegel.dataset import load_raw_corpus, load_sentence_corpus  # noqa # py
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer  # noqa # pylint: disable=unused-import, wrong-import-position, line-too-long
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel import Token # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel import Token, encode # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.ml import create_model, load_model, save_model  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+import scipy
+from .context import encode, Token
+
+
+__famous_quote__ = "Merhaba Dünya. Biz dostuz. Barış için geldik."
+
+
+@pytest.mark.parametrize('emb_type, out_type', [('bert', np.ndarray),
+                                                ('tfidf', scipy.sparse.csr_matrix),
+                                                ('glove', ValueError)])
+def test_encode_sent(emb_type, out_type):
+    if emb_type == 'glove':
+        with pytest.raises(out_type, match=r".*Not a valid embedding type .*"):
+            encode(__famous_quote__, embed=emb_type, level='sentence')
+    else:
+        enc = encode(__famous_quote__, embed=emb_type, level='sentence')
+        assert isinstance(enc, out_type)
+        if emb_type == "tfidf":
+            assert enc.shape == (3, len(Token.vocabulary()))
+        elif emb_type == 'bert':
+            assert enc.shape == (3, 768)
+
+
+@pytest.mark.parametrize('emb_type', ["bert", "tfidf", "glove"])
+def test_encode_doc(emb_type):
+    if emb_type == "tfidf":
+        enc = encode(__famous_quote__, embed=emb_type, level='document')
+        assert enc.shape == (1, len(Token.vocabulary()))
+    elif emb_type == "bert":
+        with pytest.raises(NotImplementedError, match=r".*not in current release.*"):
+            encode(__famous_quote__, embed=emb_type, level='document')
+    elif emb_type == "glove":
+        with pytest.raises(ValueError, match=r".*Not a valid embedding type .*"):
+            encode(__famous_quote__, embed=emb_type, level='document')


### PR DESCRIPTION
Now that SadedeGel has reached a certain level with its building block and their properties, some users can benefit from higher level functionalities. 

Industrial strength NLP libraries such as [flair](https://github.com/flairNLP/flair) and [bert-as-a-service](https://github.com/hanxiao/bert-as-service) have `encode`/`embed` like high level API to extract embeddings from a given text. Some SadedeGel user can benefit from such without need to reach properties of building blocks. 

For example given a dataframe with tweets a user can:
```python
from sadedegel import encode

df['tweet_bert'] = df['tweet'].apply(lambda x: encode(x, level='document'))
```

OR
```python
df['tweet_tfidf'] = df['tweet'].apply(lambda x: encode(x, embed='tfidf', level='document'))
```
