### PR TITLE
Recompute tokens if tokenizer changed

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -167,6 +167,7 @@ class Sentences:
         self.document = doc
         self._bert = None
         self.toks = None
+        self._tokenizer_used = None
 
     @staticmethod
     def set_word_tokenizer(tokenizer_name):
@@ -188,8 +189,9 @@ class Sentences:
 
     @property
     def tokens(self):
-        if self._tokens is None:
+        if self._tokens is None or Sentences.tokenizer.__name__ != self._tokenizer_used:
             self._tokens = Sentences.tokenizer(self.text)
+            self._tokenizer_used = Sentences.tokenizer.__name__
 
         return self._tokens
 

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -133,3 +133,12 @@ def test_doc_level_tf_idf_value():
 def test_doc_level_tf_idf_type():
     d = Doc("Ali topu tut. Ömer ılık süt iç.")
     assert isspmatrix_csr(d.tfidf())
+
+
+def test_tokens_recomputing_on_tokenizer_change():
+    with tokenizer_context(BertTokenizer.__name__):
+        d = Doc("Tokenizer değişimini test ediyorum")
+        assert d[0].tokens == ['Tok', '##enize', '##r', 'değişimin', '##i', 'test', 'ediyorum']
+
+    with tokenizer_context(SimpleTokenizer.__name__): # note that Doc object is not recreated
+        assert d[0].tokens == ['Tokenizer', 'değişimini', 'test', 'ediyorum']


### PR DESCRIPTION
Sentences object's tokens are now recomputed on access if tokenizer changed since last time they were generated.

resolves #135 