### PR TITLE
Evaluate TFIDF Summarizer with Various TF and IDF implementations [resolves #127]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -16,6 +16,7 @@ from .util import tr_lower, select_layer, __tr_lower_abbrv__, flatten, pad
 from .word_tokenizer import get_default_word_tokenizer, WordTokenizer
 from .token import Token
 from ..about import __version__
+from ..config import configuration
 
 
 class Span:
@@ -158,7 +159,7 @@ class Span:
 
 
 class Sentences:
-    tf_type = 'binary'
+    tf_type = configuration['tf']
 
     def __init__(self, id_: int, text: str, doc):
         self.id = id_
@@ -258,6 +259,8 @@ class Sentences:
                     'freq': self.freq_tf(),
                     'log_norm': self.log_norm_tf(),
                     'double_norm': self.double_norm_tf()}
+        if Sentences.tf_type != configuration['tf']:  # Check for config change
+            Sentences.tf_type = configuration['tf']
         return tf_funcs[Sentences.tf_type]
 
     @property

--- a/sadedegel/summarize/README.md
+++ b/sadedegel/summarize/README.md
@@ -47,13 +47,15 @@ ground truth human annotation (Best possible total `relevance` score that can be
 | Rouge1 Summarizer (precision) - bert    |        0.5295 |        0.6500 |        0.7748 |
 | Rouge1 Summarizer (recall) - bert       |    0.6851 |        0.7585 |        0.8488 |
 | Length Summarizer (char) - bert         |        0.6843 |        0.7588 |        0.8483 |
-| Length Summarizer (token) - bert        |        **0.6856** |        0.7584 |        **0.8520** |
+| Length Summarizer (token) - bert        |        0.6856 |        0.7584 |        0.8520 |
 | KMeans Summarizer - bert                |        0.6599 |        0.7434 |        0.8344 |
 | AutoKMeans Summarizer - bert            |        0.6608 |        0.7418 |        0.8333 |
 | DecomposedKMeans Summarizer - bert      |        0.6579 |        0.7440 |        0.8341 |
 | TextRank(0.05) Summarizer (BERT) - bert |        0.6212 |        0.7010 |        0.8000 |
 | TextRank(0.5) Summarizer (BERT) - bert  |        0.6232 |        0.7005 |        0.7998 |
-| TFIDF Summarizer - bert                 |        0.6781 |        **0.7592** |        0.8504 |
+| TFIDF (Binary)(Smooth) Summarizer - bert|        0.6781 |       0.7592 |        0.8504 |
+| TFIDF (Raw/Freq)(Smooth) Summarizer - bert|        0.6797 |        **0.7646** |        0.8536 |
+| TFIDF (Log Norm)(Smooth) Summarizer - bert|      **0.6920** |        0.7642 |       **0.8540** 
 
 
 

--- a/sadedegel/summarize/tf_idf.py
+++ b/sadedegel/summarize/tf_idf.py
@@ -8,7 +8,7 @@ from ._base import ExtractiveSummarizer
 
 
 class TFIDFSummarizer(ExtractiveSummarizer):
-    tags = ExtractiveSummarizer.tags + ['ml']
+    tags = ExtractiveSummarizer.tags + ['ml', 'tfidf']
 
     def __init__(self, normalize=True):
         super().__init__(normalize)

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -131,7 +131,7 @@ def test_doc_level_tfidf():
 
 def test_doc_level_tf_idf_value():
     d = Doc("Ali topu tut. Ömer ılık süt iç.")
-    assert np.sum(d.tfidf().toarray()) == pytest.approx(31.938)
+    assert np.sum(d.tfidf().toarray()) == pytest.approx(32.938034)
 
 
 def test_doc_level_tf_idf_type():


### PR DESCRIPTION
**`test_buildingblocks.py`:**
- Previous test case for `test_doc_level_tf_idf_type` was based on `binary` TF implementation as default.
- Change test case for default `raw` configuration. Case tf values are calculated by hand to derive the value.

**`tf_idf.py`:**
- Add `tfidf` tag to summarizer for filtering during evaluation to use `tf_context` and `idf_context` exclusively for the `TFIDFSummarizer`.

**`doc.py`:**
- New `set_config` does not set the value for `Sentences.tf_type`.
- Implement TF configuration read based on IDF implementation.
- Keep `Sentences.tf_type` for tests.

**`__main__.py`:**
- Use `configs` to get and crawl over tf-idf combinations.
- Use `tfidf` filter to apply evaluation loop separately on `TFIDFSummarizer` under `tf_context`,`idf_context` CMs.
- Display TF type - IDF type pair in CL during eval and final table.

**`README.md`:**
- Update table with final scores and improved results.
- Best perfomance in all `k`s are now held by `TFIDFSummarizer`