### PR TITLE
Add Kaggle to README.md badge that directs to Kaggle notebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Development of the library takes place as a part of [Açık Kaynak Hackathon Pro
 ![Last Commit](https://img.shields.io/github/last-commit/globalmaksimum/sadedegel?style=plastic&logo=GitHub)
 [![Binder](https://mybinder.org/badge_logo.svg?style=plastic)](https://mybinder.org/v2/gh/GlobalMaksimum/sadedegel.git/master?filepath=notebook%2FBasics.ipynb)
 [![Slack](https://img.shields.io/static/v1?logo=slack&style=plastic&color=blueviolet&label=slack&labelColor=grey&message=sadedegel)](https://join.slack.com/t/sadedegel/shared_invite/zt-h77u6aeq-VzEorB5QLHyJV90Fv4Ky3A)
+[![Kaggle](http://img.shields.io/static/v1?logo=kaggle&style=plastic&color=blue&label=kaggle&labelColor=grey&message=notebooks)](https://www.kaggle.com/search?q=sadedegel+in%3Anotebooks)
 
 
 ## 📖 Documentation


### PR DESCRIPTION
- `Kaggle` badge directs to Kaggle search query "sadedegel" limited with notebooks.
- Notebooks that include the word `sadedegel` are listed.
- Example notebooks will be hosted on Kaggle notebooks.
- I believe this will also encourage people to load Turkish NLP datasets on Kaggle for the use of SadedeGel. We can even encourage In-Class TR-NLP competitions in the future.