### PR TITLE
Create SadedeGel Classification over TSCorpus

### DIFF
--- a/sadedegel/classification/__init__.py
+++ b/sadedegel/classification/__init__.py
@@ -1,0 +1,1 @@
+from .news import NewsClassifier

--- a/sadedegel/classification/_base.py
+++ b/sadedegel/classification/_base.py
@@ -1,0 +1,43 @@
+from typing import List, Union
+import numpy as np  # type: ignore
+from abc import ABC, abstractmethod
+from ..bblock import Doc
+
+
+class BaseClassifier(ABC):
+
+    tags = ["classification"]
+
+    def __init__(self, base_model=None, embedding_type=None):
+        self.base_model = base_model
+        self.embedding_type = embedding_type
+
+    @abstractmethod
+    def _load_model(self):
+        pass
+
+    @abstractmethod
+    def _get_embeddings(self, document):
+        pass
+
+    @abstractmethod
+    def _predict(self):
+        pass
+
+    def predict(self, document: Union[Doc, str]):
+        if isinstance(document, Doc):
+            pass
+        elif isinstance(document, str):
+            document = Doc(document)
+
+        prediction = self._predict(
+            self._get_embeddings(document)
+        )
+
+        return prediction
+
+    def __contains__(self, tag: str) -> bool:
+        """Check whether instance tags contain a given tag for filtering summarizers.
+        """
+
+        return tag in self.tags

--- a/sadedegel/classification/news.py
+++ b/sadedegel/classification/news.py
@@ -1,0 +1,36 @@
+from ._base import BaseClassifier
+from pathlib import Path
+import os
+import joblib
+from ..bblock import Doc
+import numpy as np
+from sadedegel.summarize import Rouge1Summarizer
+
+
+class NewsClassifier(BaseClassifier):
+
+    tags = BaseClassifier.tags + ['news', 'tscorpus']
+
+    def __init__(self, base_model="MultinomialNB", embedding_type="bert"):
+        self.base_model = base_model
+        self.embedding_type = embedding_type
+
+    def _load_model(self):
+        modelpath = Path(os.path.dirname(__file__)) / "models" / f"{self.base_model}_{self.embedding_type}.joblib"
+        if os.path.exists(modelpath):
+            return joblib.load(modelpath)
+        else:
+            raise FileNotFoundError("Cannot find a trained model! "
+                                    "Train and dump a model using SadedeGel classification API.")
+
+    def _get_embeddings(self, document: Doc):
+        if self.embedding_type == "bert":
+            weights = Rouge1Summarizer().predict(document).reshape(-1, 1)
+            emb = np.sum(weights * document.bert_embeddings, axis=0)
+        else:
+            raise NotImplementedError("Other embeddings are not implemented for SadedeGel classification API")
+        return emb
+
+    def _predict(self, embeddings):
+        model = self._load_model()
+        return model.predict(embeddings)


### PR DESCRIPTION
- Create `BaseClassifier` Class as abstract class.
- A `SadedeGel Classifier` should receive: 
          1. Base Model Type
          2. Embedding Type

upon initialization.

- User will either initialize a `Doc` object from document to be classified or use its `str` form.
- A model trained by SadedeGel training CLI will be loaded to predict the new document.
- Loaded model will be based on `base_model` and `embedding_type`.
- Classifier will extract document embeddings implicitly based on initialized embedding type.
- Embeddings will go through the model trained with same `embedding_type`.
- Create `NewsClassifier` class for building a classification pipeline over TSCorpus Dataset.


```python

from sadedegel.classification import NewsClassifier

text = "Avşar kızı Gülben Ergen hakkında zehir zemberek konuştu. Kaya Çilingiroğlu arada kaldı."

clf = NewsClassifier(base_model="MultinomialNB", embedding_type="bert")
kategori = clf.predict(text)
