### PR TITLE
Handle out of bound summary lengths. [resolves #166]

### DIFF
--- a/sadedegel/about.py
+++ b/sadedegel/about.py
@@ -1,5 +1,5 @@
 __title__ = "sadedegel"  # pragma: no cover
-__version__ = "0.15.2.2"  # pragma: no cover
+__version__ = "0.15.2.3"  # pragma: no cover
 __release__ = True  # pragma: no cover
 __download_url__ = "https://github.com/globalmaksimum/sadedegel/releases"  # pragma: no cover
 __herokuapp_url__ = "https://sadedegel.herokuapp.com"  # pragma: no cover

--- a/sadedegel/summarize/_base.py
+++ b/sadedegel/summarize/_base.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 import numpy as np  # type: ignore
 from abc import ABC, abstractmethod
+import warnings
 from ..bblock import Doc, Sentences
 
 
@@ -57,12 +58,21 @@ class ExtractiveSummarizer(ABC):
     def __call__(self, sents: Union[Doc, List[Sentences], List[str]], k: int) -> List[Sentences]:
 
         sents = get_sentences_list(sents)
-        scores = self.predict(sents)
 
-        topk_inds = np.argpartition(scores, k)[-k:]  # returns indices of k top sentences
-        topk_inds.sort()  # fix the order of sentences
+        if k > len(sents):
+            warnings.warn("State a summary size shorter than document's sentence count.", UserWarning)
+            summ = None
+        elif len(sents) == k:
+            summ = sents
+        elif k == 0:
+            summ = None
+        else:
+            scores = self.predict(sents)
 
-        summ = [sents[i] for i in topk_inds]
+            topk_inds = np.argpartition(scores, k)[-k:]  # returns indices of k top sentences
+            topk_inds.sort()  # fix the order of sentences
+
+            summ = [sents[i] for i in topk_inds]
 
         return summ
 

--- a/tests/summarizer/test_k_len.py
+++ b/tests/summarizer/test_k_len.py
@@ -1,0 +1,30 @@
+from .context import Doc
+from .context import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer
+from .context import KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer, TextRank, TFIDFSummarizer
+from pytest import warns
+import pytest
+import itertools
+
+famous_quote = "Merhaba dünya. Barış için geldik. Sizi lazerlerimizle eritmeyeceğiz."
+
+ks = [0, 1, 2, 3, 4]
+summarizers = [RandomSummarizer, PositionSummarizer,
+               LengthSummarizer, BandSummarizer, Rouge1Summarizer,
+               KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer,
+               TextRank, TFIDFSummarizer]
+
+
+@pytest.mark.parametrize("k, summarizer", itertools.product(ks, summarizers))
+def test_k(k, summarizer):
+    d = Doc(famous_quote)
+    if k > len(d):
+        with warns(UserWarning, match=r"State a summary size"):
+            summary = summarizer()(d, k=k)
+    elif k == 0:
+        assert not LengthSummarizer()(d, k=k)
+    else:
+        assert len(LengthSummarizer()(d, k=k)) == k
+
+
+
+


### PR DESCRIPTION
**Old version:**
- Out of bound error if `k=>len(doc)`.
- Still returns text if `k==0`

**Hotfix/0.15.2.3**
- `UserWarning` if `k>len(doc)`
- Return all sentences if `k==len(doc)`
- Return `None` if `k==0`