### PR TITLE
Handle seentences that pass 512 tokens during bert_embeddings generation [resolves #170]

### DIFF
--- a/sadedegel/config.py
+++ b/sadedegel/config.py
@@ -104,7 +104,9 @@ def show_config(config, section=None):
     descriptions = {"default__tokenizer": "Word tokenizer to use",
                     "tf__method": "Method used in term frequency calculation",
                     "tf__double_norm_k": "Smooth parameter used by double norm term frequency method.",
-                    "idf__method": "Method used in Inverse Document Frequency calculation"}
+                    "idf__method": "Method used in Inverse Document Frequency calculation",
+                    "exceeding_sentence__method": "Method to divide sentence that exceeds 512 token length during BERT "
+                                                  "embedding generation"}
 
     default_config = ConfigParser()
     default_config.read([Path(dirname(__file__)) / 'default.ini'])

--- a/sadedegel/default.ini
+++ b/sadedegel/default.ini
@@ -9,3 +9,6 @@ double_norm_k = 0.5
 
 [idf]
 method = smooth
+
+[exceeding_sentence]
+method = slide

--- a/tests/test_buildingblocks.py
+++ b/tests/test_buildingblocks.py
@@ -40,6 +40,17 @@ def test_bert_embedding_generation(tokenizer):
             assert d.bert_embeddings.shape == (2, 768)
 
 
+@pytest.mark.parametrize("exceeding_sentence_method", ["slice", "slide"])
+def test_bert_embedding_exceed(exceeding_sentence_method):
+    with config_context(exceeding_sentence__method=exceeding_sentence_method) as Doc2:
+        d = Doc2("merhaba " * 514 + ".")
+
+        if exceeding_sentence_method == 'slide':
+            assert d.bert_embeddings.shape == (5, 768)
+        elif exceeding_sentence_method == 'slice':
+            assert d.bert_embeddings.shape == (2, 768)
+
+
 @pytest.mark.parametrize('tf_type', ['binary', 'raw', 'freq', 'log_norm', 'double_norm'])
 def test_tfidf_embedding_generation(tf_type):
     with tf_context(tf_type):


### PR DESCRIPTION
- Add method as a configuration `slice` or `slide`.
- Method comes from `DocBuilder`
- `max_length` is clipped at 512.
- Keep `parent_sentence` index to detect which embeddings are needed to be averaged to obtain the parent sentence embedding.