### PR TITLE
Add emoji bank and emoji detection capability to tokenizers.

### DIFF
--- a/prod.requirements.txt
+++ b/prod.requirements.txt
@@ -17,3 +17,5 @@ tabulate==0.8.7
 
 rich
 lexrank
+
+emoji>=0.4.5,<1.0.0

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -440,6 +440,7 @@ class Document(TFImpl, IDFImpl):
 
                 DocBuilder.bert_model = BertModel.from_pretrained("dbmdz/bert-base-turkish-cased",
                                                                   output_hidden_states=True)
+                DocBuilder.bert_model.resize_token_embeddings(35779)
                 DocBuilder.bert_model.eval()
 
             with torch.no_grad():

--- a/sadedegel/bblock/util.py
+++ b/sadedegel/bblock/util.py
@@ -4,12 +4,15 @@ import warnings
 from collections import defaultdict
 from os.path import dirname
 from pathlib import Path
+from emoji import UNICODE_EMOJI
 
 __tr_upper__ = "ABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ"
 __tr_lower__ = "abcçdefgğhıijklmnoöprsştuüvyz"
 
 __tr_lower_abbrv__ = ['hz.', 'dr.', 'prof.', 'doç.', 'org.', 'sn.', 'st.', 'mah.', 'mh.', 'sok.', 'sk.', 'alb.', 'gen.',
                       'av.', 'ist.', 'ank.', 'izm.', 'm.ö.', 'k.k.t.c.']
+
+__emojis__ = {e.replace(' ', ''): t for e, t in UNICODE_EMOJI.items()}
 
 
 def tr_lower(s: str) -> str:

--- a/sadedegel/bblock/word_tokenizer.py
+++ b/sadedegel/bblock/word_tokenizer.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 from .word_tokenizer_helper import word_tokenize
-from .util import normalize_tokenizer_name
+from .util import normalize_tokenizer_name, __emojis__
 from .vocabulary import Vocabulary
 from ..about import __version__
 import warnings
@@ -60,6 +60,7 @@ class BertTokenizer(WordTokenizer):
             import torch
             from transformers import AutoTokenizer
             self.tokenizer = AutoTokenizer.from_pretrained("dbmdz/bert-base-turkish-cased")
+            self.tokenizer.add_tokens(list(__emojis__.keys()))
 
         return self.tokenizer.tokenize(text)
 

--- a/sadedegel/bblock/word_tokenizer_helper.py
+++ b/sadedegel/bblock/word_tokenizer_helper.py
@@ -31,7 +31,7 @@ date_2_re = re.compile(
     r'\b(?P<day>0?[0-9]|1[0-9]|2[0-9]|3[01])(?:\s+|[:\-\./])(?P<month>(?:1[0-2]|0?[1-9]))(?:\s+|[:\-\./])(?P<year>\d{4})',
     flags=re.IGNORECASE)
 space = re.compile(r"\s+")
-token_re = re.compile(r"[@]?[a-zA-ZşŞiİıIğĞüÜöÖçÇ0-9]+|[\.]")
+token_re = re.compile(r"[@]?[a-zA-ZşŞiİıIğĞüÜöÖçÇ0-9]+|[\.]+|[\u263a-\U0001f645]")
 
 puncts = string.punctuation + '”“’‘…'
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -8,7 +8,7 @@ from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSumm
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import Token # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__, __emojis__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.ml import create_model, load_model, save_model  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.metrics import rouge1_score # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -1,0 +1,40 @@
+import pytest
+from .context import __emojis__
+from .context import Doc
+from .context import tokenizer_context
+
+
+__famous_quote__ = "Merhaba dünya 🌎 . Biz dostuz 👽 ."
+__famous_quote2__ = "Merhaba dünya🌎. Biz dostuz👽."
+__famous_quote3__ = "🤪🤪🤪🤪🤭🤭🤭🤭🤭"
+
+
+def test_emoji_bank():
+    assert len(__emojis__) == 3859
+
+
+@pytest.mark.parametrize("tokenizer", ["simple", "bert"])
+def test_emoji_tokenization(tokenizer):
+    with tokenizer_context(tokenizer) as Doc2:
+        d = Doc2(__famous_quote__)
+        d2 = Doc2(__famous_quote2__)
+        d3 = Doc2(__famous_quote3__)
+    if tokenizer == 'simple':
+        assert d.tokens == ["Merhaba", "dünya", "🌎", ".", "Biz", "dostuz", "👽", "."]
+        assert d2.tokens == ["Merhaba", "dünya", "🌎", ".", "Biz", "dostuz", "👽", "."]
+        assert d3.tokens == []
+    elif tokenizer == 'bert':
+        assert d.tokens == ["Merhaba", "dünya", "🌎", ".", "Biz", "dostu", "##z", "👽", "."]
+        assert d2.tokens == ["Merhaba", "dünya", "🌎", ".", "Biz", "dostu", "##z", "👽", "."]
+        assert d3.tokens == ["🤪", "🤪", "🤪", "🤪", "🤭", "🤭", "🤭", "🤭", "🤭"]
+
+
+def test_emoji_vectorization():
+    d = Doc(__famous_quote__)
+    d2 = Doc(__famous_quote3__)
+
+    assert d.bert_embeddings.shape == (2, 768)
+    assert d.tfidf_embeddings.shape == (2, 27744)
+
+    assert d2.bert_embeddings.shape == (1, 768)
+    assert d2.tfidf_embeddings.shape == (1, 27744)


### PR DESCRIPTION
- Current tokenizers both `simple` and `bert` overlooks emojis.
- `simple` eliminates them and `bert` turns them into unknown `[UNK]` tokens.
- `simple` tokenizer is regex based. Add emoji range to the token regex.
- `bert` tokenizer needs emojis to be defined in its vocabulary.
- An emoji bank is incorporated into `bblock.util` it is the same bank used by SpaCy Emoji extension.
- The emoji bank is added to `bert` tokenizer vocabulary with `.add_tokens` built-in method.
- `bert` model needs to recognize new vector length given the new additions to vobabulary otherwise producing `bert_embeddings` for sentences with emojis will raise error.
- Adding emoji bank increases vocab size to 35779 from 32000. Tokens embeddings are resized accordingly with built-int method.
- Add relevant tests for tokenizing and vectorizing documents that contain emoji.

**Moving Forward**
- Adding emoji bank to tokenizer and resizing token embeddings at each call is redundant. Emoji enhanced tokenizer and model should be serialized and imported from a data source instead of `dbmz/bert-base-turkish-cased`
- Now that tokenizers know emojis, new vocabulary can be built including emojis. After that:
      -  `tf-idf` will contain emoji occurence. 
      - `Token` object will have `.is_emoji` as well as `Doc`, `Sentence` can contain `.has_emoji` attribute.