### PR TITLE
Remove tok_eval import from tscorpus/__main__.py [resolves #187]

### DIFF
--- a/sadedegel/dataset/tscorpus/__main__.py
+++ b/sadedegel/dataset/tscorpus/__main__.py
@@ -11,7 +11,7 @@ import boto3
 
 from loguru import logger
 
-from ._core import load_tokenization_tokenized, load_tokenization_raw, CORPUS_SIZE, tok_eval, tarballs
+from ._core import load_tokenization_tokenized, load_tokenization_raw, CORPUS_SIZE, tarballs
 
 from rich.console import Console
 from rich.table import Table


### PR DESCRIPTION
Deleted unused and unimplemented `tok_eval`import.

Will continue on #186 by opening a feature branch from this branch.