### PR TITLE
Add additive smoothing to freq and double_norm tf_types [resolves #193]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -190,23 +190,26 @@ class TFImpl:
     def binary_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False):
         return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct).clip(max=1)
 
-    def freq_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, ):
-        return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / self.raw_tf(drop_stopwords, lowercase,
-                                                                                             drop_prefix,
-                                                                                             drop_punct).sum()
+    def freq_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, epsilon=1e-5):
+        return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / (self.raw_tf(drop_stopwords, lowercase,
+                                                                                              drop_prefix,
+                                                                                              drop_punct).sum() +
+                                                                                  epsilon)
 
-    def log_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, ):
+    def log_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False):
         return np.log1p(self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct))
 
-    def double_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, k=0.5):
+    def double_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, k=0.5,
+                       epsilon=1e-5):
         if not (0 < k < 1):
             raise ValueError(f"Ensure that 0 < k < 1 for double normalization term frequency calculation ({k} given)")
 
         return k + (1 - k) * (
-                self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / self.raw_tf(drop_stopwords,
-                                                                                              lowercase,
-                                                                                              drop_prefix,
-                                                                                              drop_punct).max())
+                self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / (self.raw_tf(drop_stopwords,
+                                                                                               lowercase,
+                                                                                               drop_prefix,
+                                                                                               drop_punct).max() +
+                                                                                   epsilon))
 
     def get_tf(self, method=TF_BINARY, drop_stopwords=False, lowercase=False, drop_suffix=False, drop_punct=False,
                **kwargs):

--- a/tests/extension/test_pipeline.py
+++ b/tests/extension/test_pipeline.py
@@ -1,10 +1,12 @@
 from .context import load_extended_raw_corpus, TfidfVectorizer, OnlinePipeline, load_raw_corpus
 
+from scipy.sparse import csr_matrix
 from sklearn.linear_model import SGDClassifier
 from sklearn.pipeline import Pipeline
 from rich.progress import track
-from itertools import tee, islice
+from itertools import tee, islice, product
 from random import randint
+import numpy as np
 
 import pytest
 from pytest import raises
@@ -61,3 +63,36 @@ def test_online_pipeline_training_divisable_batch():
 
     with raises(ValueError, match=r"Ensure that X contains at least one valid document.*"):
         pipeline.partial_fit(batch, [1 for _ in range(len(batch))])
+
+
+tf_types = ['freq', 'double_norm']
+texts = ['ıyi', '*******', '😗😗😗😗😗😗😗😗😗😗']
+
+
+@pytest.mark.parametrize('tf_type, text', product(tf_types, texts))
+def test_tfidf_vectorizer_smoothing(tf_type, text):
+    pipeline = OnlinePipeline([('tfidf', TfidfVectorizer(tf_method=tf_type, idf_method='smooth')),
+                           ('model', SGDClassifier())])
+
+    X1, X2 = tee(islice(load_extended_raw_corpus(), 101), 2)
+
+    total = sum(1 for _ in X1)
+
+    batch = []
+    for doc in track(X2, total=total):
+        batch.append(doc)
+
+        if len(batch) == BATCH_SIZE:
+            pipeline.partial_fit(batch, [randint(0, 1) for _ in range(len(batch))], classes=[0, 1])
+
+            batch.clear()
+
+    pipeline.partial_fit(batch, [1 for _ in range(len(batch))])
+
+    assert pipeline.predict([text]) > -1  # Can perform inference without value error.
+
+
+@pytest.mark.parametrize('tf_type, text', product(tf_types, texts))
+def test_zero_vector_edge_cases(tf_type, text):
+    vectorizer = TfidfVectorizer(tf_method=tf_type, idf_method='smooth')
+    assert vectorizer.fit_transform([text]).sum() == 0


### PR DESCRIPTION
- Additive smoothing with infinitesimal `epsilon` to denominaor of `freq_tf` and `double_norm_tf` calculations, ensures returning zero vectors and avoids division by zero.
- `TfIdfVectorizer` does not return `nan` vectors.
- Open to re-implementation by checking the denominator term and returning only the numerator which is a zero vector.