### PR TITLE
Implement a prebuilt profanity classifier [resolves #189]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@ sadedegel/dataset/raw/*.txt filter=lfs diff=lfs merge=lfs -text
 sadedegel/dataset/sents/*.json filter=lfs diff=lfs merge=lfs -text
 sadedegel/dataset/annotated/*.json filter=lfs diff=lfs merge=lfs -text
 sadedegel/bblock/data/vocabulary.json filter=lfs diff=lfs merge=lfs -text
-sadedegel/prebuilt/model/news_classification.joblib filter=lfs diff=lfs merge=lfs -text
+sadedegel/prebuilt/model/*.joblib filter=lfs diff=lfs merge=lfs -text
+sadedegel/prebuilt/data/*/*.csv.gz filter=lfs diff=lfs merge=lfs -t

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -191,9 +191,11 @@ class TFImpl:
         return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct).clip(max=1)
 
     def freq_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, ):
-        return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / self.raw_tf(drop_stopwords, lowercase,
-                                                                                             drop_prefix,
-                                                                                             drop_punct).sum()
+        normalizing_factor = self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct).sum()
+        if normalizing_factor != 0:
+            return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / normalizing_factor
+        else:
+            return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct)
 
     def log_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False, ):
         return np.log1p(self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct))
@@ -202,11 +204,12 @@ class TFImpl:
         if not (0 < k < 1):
             raise ValueError(f"Ensure that 0 < k < 1 for double normalization term frequency calculation ({k} given)")
 
-        return k + (1 - k) * (
-                self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / self.raw_tf(drop_stopwords,
-                                                                                              lowercase,
-                                                                                              drop_prefix,
-                                                                                              drop_punct).max())
+        normalizing_factor = self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct).max()
+        if normalizing_factor != 0:
+            return k + (1 - k) * (
+                    self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct) / normalizing_factor)
+        else:
+            return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct)
 
     def get_tf(self, method=TF_BINARY, drop_stopwords=False, lowercase=False, drop_suffix=False, drop_punct=False,
                **kwargs):

--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -28,3 +28,25 @@ y_pred_label = [CATEGORIES.index(_y_pred) for _y_pred in y_pred]
 #### Accuracy
 
 Current prebuilt model has an average class prediction cv-3 accuracy of `0.746` 
+
+### Turkish Tweets Profanity Classification
+
+This classifier assigns Turkish tweets to one of `PROFANE`, `PROPER` labels based on whether a tweet contains a profane language or not by using a `sadedegel`pipeline.
+
+#### Load Model
+```python
+from sadedegel.prebuilt import tweet_profanity
+
+model = tweet_profanity.load()  # Load latest version
+
+y_pred = model.predict(['bir takım ağza alınmayacak sözcükler.'])
+``` 
+To convert predictions to profanity label by class mapping:
+
+```python
+y_pred_profanity = [tweet_profanity._classes[pred] for pred in predictions]
+```
+
+#### Accuracy
+
+Current prebuilt tweet profanity model has an **ROC-AUC** score of `0.824` on 3-fold CV.

--- a/sadedegel/prebuilt/data/profanity/profanity_train.csv.gz
+++ b/sadedegel/prebuilt/data/profanity/profanity_train.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49b2df7177719329e774cc3e83ac97f00919b1b6391ab87b2ba5eb43631e4ffd
+size 1799282

--- a/sadedegel/prebuilt/model/tweet_profanity_v1.joblib
+++ b/sadedegel/prebuilt/model/tweet_profanity_v1.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:749425734c1bfc62d02862d9c4854d87ce59fd6c0cd7b451451bea675884a316
+size 2379648

--- a/sadedegel/prebuilt/tweet_profanity.py
+++ b/sadedegel/prebuilt/tweet_profanity.py
@@ -1,0 +1,79 @@
+from math import ceil
+
+import numpy as np
+from joblib import dump, load as jl_load
+
+from pathlib import Path
+from os.path import dirname
+
+from rich.console import Console
+from rich.progress import Progress
+
+from sklearn.linear_model import SGDClassifier
+from sadedegel.extension.sklearn import TfidfVectorizer, OnlinePipeline
+
+from sklearn.utils import compute_class_weight
+
+console = Console()
+
+_classes = {0: 'PROPER',
+            1: 'PROFANE'}
+
+
+def empty_model(cw='balanced'):
+    return OnlinePipeline([("tfidf", TfidfVectorizer(tf_method='freq', idf_method='smooth',
+                                                     drop_stopwords=False, drop_suffix=False)),
+                           ("sgd_model", SGDClassifier(alpha=1e-7,
+                                                       loss='log',
+                                                       class_weight=cw,
+                                                       n_jobs=-1, random_state=42))])
+
+
+def build(max_rows=15000):
+    try:
+        import pandas as pd
+    except ImportError:
+        console.log(("pandas package is not a general sadedegel dependency."
+                     " But we do have a dependency on building our prebuilt models"))
+
+    datadir = Path(dirname(__file__)) / "data" / "profanity" /"profanity_train.csv.gz"
+    df = pd.read_csv(datadir)
+    class_weights = compute_class_weight('balanced', classes=list(_classes.keys()), y=df.offensive.values)
+
+    CORPUS_SIZE = len(df)
+
+    if max_rows > 0:
+        df = df.sample(max_rows)
+
+    CLASS_WEIGHT = {0: class_weights[0],
+                    1: class_weights[1]}
+    BATCH_SIZE = 100
+
+    console.log(f"Corpus Size: {CORPUS_SIZE}")
+    console.log(f"Training Size: {len(df)}")
+
+    n_split = ceil(len(df) / BATCH_SIZE)
+    console.log(f"{n_split} batches of {BATCH_SIZE} instances...")
+
+    batches = np.array_split(df, n_split)
+
+    pipeline = empty_model(cw=CLASS_WEIGHT)
+
+    for batch in batches:
+        pipeline.partial_fit(batch.text, batch.offensive, classes=[i for i in range(len(_classes))])
+
+    console.log("Model build [green]DONE[/green]")
+
+    model_dir = Path(dirname(__file__)) / 'model'
+
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    dump(pipeline, (model_dir / 'tweet_profanity_v1.joblib').absolute(), compress=('gzip', 9))
+
+
+def load(model_version='v1'):
+    return jl_load(Path(dirname(__file__)) / 'model' / f"tweet_profanity_{model_version}.joblib")
+
+
+if __name__ == "__main__":
+    build()

--- a/tests/prebuilt/context.py
+++ b/tests/prebuilt/context.py
@@ -4,5 +4,5 @@ from pathlib import Path
 sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.prebuilt import news_classification  # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.prebuilt import news_classification, tweet_profanity  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tscorpus import CATEGORIES # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/prebuilt/test_tweet_profanity.py
+++ b/tests/prebuilt/test_tweet_profanity.py
@@ -1,0 +1,14 @@
+from .context import tweet_profanity
+from sklearn.linear_model import SGDClassifier
+
+
+def test_model_load():
+    model = tweet_profanity.load('v1')
+    assert isinstance(model['sgd_model'], SGDClassifier)
+
+
+def test_inference():
+    model = tweet_profanity.load('v1')
+    pred = model.predict(['amk hepinizin.', 'harika fikir.'])
+    assert tweet_profanity._classes[pred[0]] == 'PROFANE'
+    assert tweet_profanity._classes[pred[1]] == 'PROPER'


### PR DESCRIPTION
**bblock/doc.py:**
- Implement a fix for returning zero vector instead of nan when the denominator/normalizing_factor is 0.
- No `epsilon` thing this time. 

**prebuilt/data:**
- Compressed training data containing binary label of `profane` and `non-profane`(proper) tweets. Evaluation data is exclusive not included.

**prebuilt/tweet_profanity.py**
- Implement `empty_model`, `build` and `load` methods.
- Implement class mappings.
- This particular problem thrives on class weights. Calculate class weights based on training data. (This is not calculated on sampled data. Instead sampling will be stratified by changing `max_rows` to `max_percentage`. Will perform this upon discussion and permission.)
- `empty_model` receives class weights for initialization.
- Eliminated `Progress` for now. It caused problems that I have not identified yet. At first I thought it was due to certain instances; but after removing `Progress` the training worked seamlessly on full training set. 
- Parameter for model are chosen in 3 fold cv. Optimizer code is exclusive not included.
- Save model with version. Use the version number for loading by adding version argument.


- Update prebuilt/README.md with usage and 3-Fold CV ROC-AUC score.