### PR TITLE
Add TFIDF setting options to TFIDFSummarizer [resolves #202]

### DIFF
--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -133,9 +133,10 @@ def evaluate(table_format, tag, debug):
     suffix = [True, False]
     lower = [True, False]
 
-    tfidf_word_settings = product(stopword, punct, suffix, lower)
+    tfidf_word_settings = list(product(stopword, punct, suffix, lower))
 
     if any(_tag in summarizer for _tag in tag):
+        c = 0
         for tf in TF_METHOD_VALUES:
             for idf in IDF_METHOD_VALUES:
                 for drop_stopwords, drop_punct, drop_suffix, lowercase in tfidf_word_settings:
@@ -143,13 +144,14 @@ def evaluate(table_format, tag, debug):
                                                  drop_suffix=drop_suffix, lowercase=lowercase)
                     if tf == "double_norm":
                         for k in [0.25, 0.5, 0.75]:
+                            c += 1
                             with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
                                                 tf__double_norm_k=k) as Doc2:
                                 t0 = time.time()
                                 table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, " \
                                             f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
                                             f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
-                                click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+                                click.echo(click.style(f"{c}-    {table_key}", fg="magenta"), nl=False)
 
                                 docs = [Doc2.from_sentences(doc['sentences']) for doc in
                                         anno]
@@ -165,12 +167,13 @@ def evaluate(table_format, tag, debug):
 
                                     scores[table_key].append((score_10, score_50, score_80))
                     else:
+                        c += 1
                         with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
                             t0 = time.time()
                             table_key = f"{name} (tf={tf}, idf={idf}, " \
                                         f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
                                         f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
-                            click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+                            click.echo(click.style(f"{c}-    {table_key}", fg="magenta"), nl=False)
 
                             docs = [Doc2.from_sentences(doc['sentences']) for doc in
                                     anno]

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from math import ceil
 from typing import List
 from loguru import logger
+from itertools import product
 
 import click
 import time
@@ -127,15 +128,48 @@ def evaluate(table_format, tag, debug):
 
     name, summarizer = "TFIDF Summarizer", TFIDFSummarizer()
 
+    stopword = [True, False]
+    punct = [True, False]
+    suffix = [True, False]
+    lower = [True, False]
+
+    tfidf_word_settings = product(stopword, punct, suffix, lower)
+
     if any(_tag in summarizer for _tag in tag):
         for tf in TF_METHOD_VALUES:
             for idf in IDF_METHOD_VALUES:
-                if tf == "double_norm":
-                    for k in [0.25, 0.5, 0.75]:
-                        with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
-                                            tf__double_norm_k=k) as Doc2:
+                for drop_stopwords, drop_punct, drop_suffix, lowercase in tfidf_word_settings:
+                    summarizer = TFIDFSummarizer(drop_stopwords=drop_stopwords, drop_punct=drop_punct,
+                                                 drop_suffix=drop_suffix, lowercase=lowercase)
+                    if tf == "double_norm":
+                        for k in [0.25, 0.5, 0.75]:
+                            with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
+                                                tf__double_norm_k=k) as Doc2:
+                                t0 = time.time()
+                                table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, " \
+                                            f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
+                                            f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
+                                click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+
+                                docs = [Doc2.from_sentences(doc['sentences']) for doc in
+                                        anno]
+
+                                for i, (y_true, d) in enumerate(zip(relevance, docs)):
+                                    dot_progress(i, len(relevance), t0)
+
+                                    y_pred = [summarizer.predict(d)]
+
+                                    score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
+                                    score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
+                                    score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
+
+                                    scores[table_key].append((score_10, score_50, score_80))
+                    else:
+                        with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
                             t0 = time.time()
-                            table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, tokenizer=bert)"
+                            table_key = f"{name} (tf={tf}, idf={idf}, " \
+                                        f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
+                                        f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
                             click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
 
                             docs = [Doc2.from_sentences(doc['sentences']) for doc in
@@ -151,25 +185,6 @@ def evaluate(table_format, tag, debug):
                                 score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
 
                                 scores[table_key].append((score_10, score_50, score_80))
-                else:
-                    with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
-                        t0 = time.time()
-                        table_key = f"{name} (tf={tf}, idf={idf}, tokenizer=bert)"
-                        click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
-
-                        docs = [Doc2.from_sentences(doc['sentences']) for doc in
-                                anno]
-
-                        for i, (y_true, d) in enumerate(zip(relevance, docs)):
-                            dot_progress(i, len(relevance), t0)
-
-                            y_pred = [summarizer.predict(d)]
-
-                            score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
-                            score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
-                            score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
-
-                            scores[table_key].append((score_10, score_50, score_80))
 
     table = [[algo, np.array([s[0] for s in scores]).mean(), np.array([s[1] for s in scores]).mean(),
               np.array([s[2] for s in scores]).mean()] for

--- a/sadedegel/summarize/tf_idf.py
+++ b/sadedegel/summarize/tf_idf.py
@@ -8,8 +8,27 @@ from ._base import ExtractiveSummarizer
 class TFIDFSummarizer(ExtractiveSummarizer):
     tags = ExtractiveSummarizer.tags + ['ml', 'tfidf']
 
-    def __init__(self, normalize=True):
+    def __init__(self, tf_method=None, idf_method=None, drop_stopwords=False, drop_suffix=False,
+                 drop_punct=False, lowercase=False, normalize=True, config=None):
         super().__init__(normalize)
+        self.drop_stopwords = drop_stopwords
+        self.drop_suffix = drop_suffix
+        self.drop_punct = drop_punct
+        self.lowercase = lowercase
+        self.config = config
+        self.tf_method = tf_method
+        self.idf_method = idf_method
 
     def _predict(self, sents: List[Sentences]):
-        return np.array([sent.tfidf().sum() for sent in sents])
+        if self.config is None:
+            self.config = sents[0].document.builder.config
+        if self.tf_method is None:
+            self.tf_method = self.config['tf']['method']
+        if self.idf_method is None:
+            self.idf_method = self.config['idf']['method']
+
+        return np.array([sent.get_tfidf(tf_method=self.tf_method,
+                                        idf_method=self.idf_method,
+                                        drop_stopwords=self.drop_stopwords,
+                                        drop_suffix=self.drop_suffix,
+                                        drop_punct=self.drop_punct).sum() for sent in sents])


### PR DESCRIPTION
- `tf` and `idf` are still set through config. Unless user spesifically specifies `tf_type` and `idf_type` during summarizer initalization.
- `drop_stopwords`, `drop_suffix`, `drop_puncts` and `lowercase` are summarizer `__init__` arguments all default to `False`.
- The parameters are passed to `get_tfidf`.
- `get_tfidf` normally requires user input for `tf_type` and `idf_type`. I bypassed this by reaching config so that `tf_context` and `idf_context` usage can be relevant in summarizer evaluation.
- I will repeat this implementation in my `feature/wip_dafajon_bm25` branch on `BM25Summarizer` since now there is a `get_bm25` implemented like `get_tfidf`in that branch.
- By this we can have full comparison of the two `information-retrieval` based summarizers in search-space of various settings.