### PR TITLE
Implement BM25 Weighting Score, Summarizer and Vector

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -330,7 +330,8 @@ class Sentences(TFImpl, IDFImpl):
 
         m_factor = k1 + 1
         add_smooth = k1 * (1 - b + b*len(self.document.tokens)/avg_doc_len)
-        score = np.sum(self.idf * (self.tf * m_factor) / (self.tf + add_smooth), dtype=np.float32)
+        len_factor = len(self.tokens)/18.14
+        score = np.sum(self.idf * (self.tf * m_factor * len_factor) / (self.tf + add_smooth), dtype=np.float32)
 
         return score
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -309,7 +309,7 @@ class Sentences(TFImpl, IDFImpl):
     def tfidf(self):
         return self.tf * self.idf
 
-    def bm25(self, k1=1.25, b=0.75) -> np.float16:
+    def bm25(self, k1=1.25, b=0.75) -> np.float32:
         """
         Calculate BM25 Weighting for a given sentence w.r.t. to the document and corpus it resides.
         More information on BM25 http://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf
@@ -330,7 +330,7 @@ class Sentences(TFImpl, IDFImpl):
 
         m_factor = k1 + 1
         add_smooth = k1 * (1 - b + b*len(self.document.tokens)/avg_doc_len)
-        score = np.sum(self.idf * (self.tf * m_factor) / (self.tf + add_smooth), dtype=np.float16)
+        score = np.sum(self.idf * (self.tf * m_factor) / (self.tf + add_smooth), dtype=np.float32)
 
         return score
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -324,6 +324,10 @@ class Sentences(TFImpl, IDFImpl):
         elif active_tokenizer == 'simple':
             avg_doc_len = 525
 
+        if k1 == 0:
+            raise UserWarning("Out of empirical bounds and involves risk of losing smoothing for a TF vector "
+                              "with zero elements.")
+
         m_factor = k1 + 1
         add_smooth = k1 * (1 - b + b*len(self.document.tokens)/avg_doc_len)
         score = np.sum(self.idf * (self.tf * m_factor) / (self.tf + add_smooth), dtype=np.float16)

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -238,7 +238,7 @@ class BM25Impl:
 
     def _sentence_len_term(self):
         if isinstance(self, Sentences):
-            return len(self.tokens)/18.14
+            return len(self.tokens)/len(self.document.tokens)
         elif isinstance(self, Document):
             return 1
 

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -87,8 +87,8 @@ class TfidfVectorizer(BaseEstimator, TransformerMixin):
 
 
 class BM25Vectorizer(BaseEstimator, TransformerMixin):
-    def __init__(self, *, tf_method='raw', idf_method='probabilistic', k1=1.25, b=0.75, drop_stopwords=True, lowercase=True,
-                 drop_suffix=True, drop_punct=True, show_progress=True):
+    def __init__(self, *, tf_method='raw', idf_method='probabilistic', k1=1.25, b=0.75, drop_stopwords=True,
+                 lowercase=True, drop_suffix=True, drop_punct=True, show_progress=True):
         self.tf_method = tf_method
         self.idf_method = idf_method
         self.lowercase = lowercase

--- a/sadedegel/summarize/__init__.py
+++ b/sadedegel/summarize/__init__.py
@@ -3,3 +3,4 @@ from .rouge import Rouge1Summarizer  # noqa: F401
 from .cluster import KMeansSummarizer, AutoKMeansSummarizer, DecomposedKMeansSummarizer  # noqa: F401
 from .rank import TextRank, LexRankSummarizer, LexRankPureSummarizer  # noqa: F401
 from .tf_idf import TFIDFSummarizer  # noqa: F401
+from .bm25 import BM25Summarizer  # noqa: F401

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -176,48 +176,52 @@ def evaluate(table_format, tag, debug):
     name, summarizer = "BM25 Summarizer", BM25Summarizer()
 
     if any(_tag in summarizer for _tag in tag):
-        for tf in TF_METHOD_VALUES:
-            for idf in IDF_METHOD_VALUES:
-                if tf == "double_norm":
-                    for k in [0.25, 0.5, 0.75]:
-                        with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
-                                            tf__double_norm_k=k) as Doc2:
-                            t0 = time.time()
-                            table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, tokenizer=bert)"
-                            click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+        for k1 in np.linspace(1.2, 2.0, 5):
+            for b in np.linspace(0.5, 0.8, 5):
+                summarizer = BM25Summarizer(k1=k1, b=b)
+                for tf in TF_METHOD_VALUES:
+                    for idf in IDF_METHOD_VALUES:
+                        if tf == "double_norm":
+                            for k in [0.25, 0.5, 0.75]:
+                                with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
+                                                    tf__double_norm_k=k) as Doc2:
+                                    t0 = time.time()
+                                    table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, k1={k1}, b={b}, " \
+                                                f"tokenizer=bert)"
+                                    click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
 
-                            docs = [Doc2.from_sentences(doc['sentences']) for doc in
-                                    anno]
+                                    docs = [Doc2.from_sentences(doc['sentences']) for doc in
+                                            anno]
 
-                            for i, (y_true, d) in enumerate(zip(relevance, docs)):
-                                dot_progress(i, len(relevance), t0)
+                                    for i, (y_true, d) in enumerate(zip(relevance, docs)):
+                                        dot_progress(i, len(relevance), t0)
 
-                                y_pred = [summarizer.predict(d)]
+                                        y_pred = [summarizer.predict(d)]
 
-                                score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
-                                score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
-                                score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
+                                        score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
+                                        score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
+                                        score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
 
-                                scores[table_key].append((score_10, score_50, score_80))
-                else:
-                    with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
-                        t0 = time.time()
-                        table_key = f"{name} (tf={tf}, idf={idf}, tokenizer=bert)"
-                        click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+                                        scores[table_key].append((score_10, score_50, score_80))
+                        else:
+                            with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
+                                t0 = time.time()
+                                table_key = f"{name} (tf={tf}, idf={idf}, k1={k1}, b={b}, tokenizer=bert)"
+                                click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
 
-                        docs = [Doc2.from_sentences(doc['sentences']) for doc in
-                                anno]
+                                docs = [Doc2.from_sentences(doc['sentences']) for doc in
+                                        anno]
 
-                        for i, (y_true, d) in enumerate(zip(relevance, docs)):
-                            dot_progress(i, len(relevance), t0)
+                                for i, (y_true, d) in enumerate(zip(relevance, docs)):
+                                    dot_progress(i, len(relevance), t0)
 
-                            y_pred = [summarizer.predict(d)]
+                                    y_pred = [summarizer.predict(d)]
 
-                            score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
-                            score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
-                            score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
+                                    score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
+                                    score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
+                                    score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
 
-                            scores[table_key].append((score_10, score_50, score_80))
+                                    scores[table_key].append((score_10, score_50, score_80))
 
     table = [[algo, np.array([s[0] for s in scores]).mean(), np.array([s[1] for s in scores]).mean(),
               np.array([s[2] for s in scores]).mean()] for

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -181,13 +181,13 @@ def evaluate(table_format, tag, debug):
     suffix = [True, False]
     lower = [True, False]
 
-    bm25_word_settings = product(stopword, punct, suffix, lower)
+    bm25_word_settings = list(product(stopword, punct, suffix, lower))
 
     if any(_tag in summarizer for _tag in tag):
         c = 0
         for k1 in np.linspace(1.2, 2.0, 5):
             for b in np.linspace(0.5, 0.8, 5):
-                for drop_stopwords, drop_punct, drop_suffix, lowercase in list(bm25_word_settings):
+                for drop_stopwords, drop_punct, drop_suffix, lowercase in bm25_word_settings:
                     for tf in TF_METHOD_VALUES:
                         for idf in IDF_METHOD_VALUES:
                             summarizer = BM25Summarizer(k1=k1, b=b,

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -26,7 +26,7 @@ from sadedegel.dataset import load_annotated_corpus
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, Rouge1Summarizer, KMeansSummarizer, \
     AutoKMeansSummarizer, \
     DecomposedKMeansSummarizer, LengthSummarizer, TextRank, LexRankSummarizer, LexRankPureSummarizer, TFIDFSummarizer, \
-    BandSummarizer
+    BandSummarizer, BM25Summarizer
 from sadedegel import Sentences
 from sadedegel.bblock import DocBuilder
 from sadedegel import tokenizer_context
@@ -125,7 +125,55 @@ def evaluate(table_format, tag, debug):
 
                     scores[f"{name} - {word_tokenizer}"].append((score_10, score_50, score_80))
 
+    # TFIDF Evaluation
     name, summarizer = "TFIDF Summarizer", TFIDFSummarizer()
+
+    if any(_tag in summarizer for _tag in tag):
+        for tf in TF_METHOD_VALUES:
+            for idf in IDF_METHOD_VALUES:
+                if tf == "double_norm":
+                    for k in [0.25, 0.5, 0.75]:
+                        with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
+                                            tf__double_norm_k=k) as Doc2:
+                            t0 = time.time()
+                            table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, tokenizer=bert)"
+                            click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+
+                            docs = [Doc2.from_sentences(doc['sentences']) for doc in
+                                    anno]
+
+                            for i, (y_true, d) in enumerate(zip(relevance, docs)):
+                                dot_progress(i, len(relevance), t0)
+
+                                y_pred = [summarizer.predict(d)]
+
+                                score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
+                                score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
+                                score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
+
+                                scores[table_key].append((score_10, score_50, score_80))
+                else:
+                    with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
+                        t0 = time.time()
+                        table_key = f"{name} (tf={tf}, idf={idf}, tokenizer=bert)"
+                        click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+
+                        docs = [Doc2.from_sentences(doc['sentences']) for doc in
+                                anno]
+
+                        for i, (y_true, d) in enumerate(zip(relevance, docs)):
+                            dot_progress(i, len(relevance), t0)
+
+                            y_pred = [summarizer.predict(d)]
+
+                            score_10 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.1))
+                            score_50 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.5))
+                            score_80 = ndcg_score(y_true, y_pred, k=ceil(len(d) * 0.8))
+
+                            scores[table_key].append((score_10, score_50, score_80))
+
+    # BM25 Evaluation
+    name, summarizer = "BM25 Summarizer", BM25Summarizer()
 
     if any(_tag in summarizer for _tag in tag):
         for tf in TF_METHOD_VALUES:
@@ -176,6 +224,7 @@ def evaluate(table_format, tag, debug):
              algo, scores in scores.items()]
 
     # TODO: Sample weight of instances.
+
     print(
         tabulate(table, headers=['Method & Tokenizer', 'ndcg(k=0.1)', 'ndcg(k=0.5)', 'ndcg(k=0.8)'],
                  tablefmt=table_format,

--- a/sadedegel/summarize/__main__.py
+++ b/sadedegel/summarize/__main__.py
@@ -184,23 +184,26 @@ def evaluate(table_format, tag, debug):
     bm25_word_settings = product(stopword, punct, suffix, lower)
 
     if any(_tag in summarizer for _tag in tag):
+        c = 0
         for k1 in np.linspace(1.2, 2.0, 5):
             for b in np.linspace(0.5, 0.8, 5):
-                for drop_stopwords, drop_punct, drop_suffix, lowercase in bm25_word_settings:
-                    summarizer = BM25Summarizer(k1=k1, b=b,
-                                                drop_stopwords=drop_stopwords, drop_punct=drop_punct,
-                                                drop_suffix=drop_suffix, lowercase=lowercase)
+                for drop_stopwords, drop_punct, drop_suffix, lowercase in list(bm25_word_settings):
                     for tf in TF_METHOD_VALUES:
                         for idf in IDF_METHOD_VALUES:
+                            summarizer = BM25Summarizer(k1=k1, b=b,
+                                                        drop_stopwords=drop_stopwords, drop_punct=drop_punct,
+                                                        drop_suffix=drop_suffix, lowercase=lowercase)
+
                             if tf == "double_norm":
                                 for k in [0.25, 0.5, 0.75]:
+                                    c += 1
                                     with config_context(tokenizer="bert", tf__method=tf, idf__method=idf,
                                                         tf__double_norm_k=k) as Doc2:
                                         t0 = time.time()
                                         table_key = f"{name} (tf={tf}, double_norm_k={k}, idf={idf}, k1={k1}, b={b}, " \
                                                     f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
                                                     f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
-                                        click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+                                        click.echo(click.style(f"{c}-    {table_key}", fg="magenta"), nl=False)
 
                                         docs = [Doc2.from_sentences(doc['sentences']) for doc in
                                                 anno]
@@ -216,12 +219,13 @@ def evaluate(table_format, tag, debug):
 
                                             scores[table_key].append((score_10, score_50, score_80))
                             else:
+                                c += 1
                                 with config_context(tokenizer="bert", tf__method=tf, idf__method=idf) as Doc2:
                                     t0 = time.time()
                                     table_key = f"{name} (tf={tf}, idf={idf}, k1={k1}, b={b}," \
                                                 f"drop_stopwords={drop_stopwords}, drop_punct={drop_punct}, " \
                                                 f"drop_suffix={drop_suffix}, lowercase={lowercase}, tokenizer=bert)"
-                                    click.echo(click.style(f"    {table_key}", fg="magenta"), nl=False)
+                                    click.echo(click.style(f"{c}-    {table_key}", fg="magenta"), nl=False)
 
                                     docs = [Doc2.from_sentences(doc['sentences']) for doc in
                                             anno]

--- a/sadedegel/summarize/bm25.py
+++ b/sadedegel/summarize/bm25.py
@@ -1,0 +1,27 @@
+from typing import List
+import numpy as np  # type: ignore
+from ._base import ExtractiveSummarizer
+from ..bblock import Sentences
+
+
+class BM25Summarizer(ExtractiveSummarizer):
+    """
+    Assign a higher importance score based on BM25 score of the sentences within the document.
+
+    k1 : Coefficient to be used for BM25 computation.
+    b : Coefficient to be used for BM25 computation.
+
+    normalize : bool, optional (default=True)
+        If ``False``, return a raw score vector.
+        Otherwise, return L2 normalized score vector.
+    """
+    tags = ExtractiveSummarizer.tags + ['self-supervised', 'ml', 'info-retrieval']
+
+    def __init__(self, k1=1.25, b=0.75, normalize=True):
+        super().__init__(normalize)
+
+        self.k1 = k1
+        self.b = b
+
+    def _predict(self, sentences: List[Sentences]):
+        return np.array([sent.bm25(k1=self.k1, b=self.b) for sent in sentences])

--- a/sadedegel/summarize/bm25.py
+++ b/sadedegel/summarize/bm25.py
@@ -15,7 +15,7 @@ class BM25Summarizer(ExtractiveSummarizer):
         If ``False``, return a raw score vector.
         Otherwise, return L2 normalized score vector.
     """
-    tags = ExtractiveSummarizer.tags + ['self-supervised', 'ml', 'info-retrieval']
+    tags = ExtractiveSummarizer.tags + ['self-supervised', 'ml', 'info-retrieval', 'bm']
 
     def __init__(self, k1=1.25, b=0.75,
                  tf_method=None, idf_method=None,

--- a/sadedegel/summarize/bm25.py
+++ b/sadedegel/summarize/bm25.py
@@ -17,11 +17,36 @@ class BM25Summarizer(ExtractiveSummarizer):
     """
     tags = ExtractiveSummarizer.tags + ['self-supervised', 'ml', 'info-retrieval']
 
-    def __init__(self, k1=1.25, b=0.75, normalize=True):
+    def __init__(self, k1=1.25, b=0.75,
+                 tf_method=None, idf_method=None,
+                 drop_stopwords=False, drop_suffix=False,
+                 drop_punct=False, lowercase=False,
+                 config=None, normalize=True):
         super().__init__(normalize)
 
         self.k1 = k1
         self.b = b
 
-    def _predict(self, sentences: List[Sentences]):
-        return np.array([sent.bm25(k1=self.k1, b=self.b) for sent in sentences])
+        self.drop_stopwords = drop_stopwords
+        self.drop_suffix = drop_suffix
+        self.drop_punct = drop_punct
+        self.lowercase = lowercase
+
+        self.config = config
+        self.tf_method = tf_method
+        self.idf_method = idf_method
+
+    def _predict(self, sents: List[Sentences]):
+        if self.config is None:
+            self.config = sents[0].document.builder.config
+        if self.tf_method is None:
+            self.tf_method = self.config['tf']['method']
+        if self.idf_method is None:
+            self.idf_method = self.config['idf']['method']
+
+        return np.array([sent.get_bm25(tf_method=self.tf_method,
+                                       idf_method=self.idf_method,
+                                       drop_stopwords=self.drop_stopwords,
+                                       drop_suffix=self.drop_suffix,
+                                       drop_punct=self.drop_punct,
+                                       k1=self.k1, b=self.b).sum() for sent in sents])

--- a/sadedegel/summarize/tf_idf.py
+++ b/sadedegel/summarize/tf_idf.py
@@ -6,7 +6,7 @@ from ._base import ExtractiveSummarizer
 
 
 class TFIDFSummarizer(ExtractiveSummarizer):
-    tags = ExtractiveSummarizer.tags + ['ml', 'tfidf']
+    tags = ExtractiveSummarizer.tags + ['ml', 'tfidf', 'info-retrieval']
 
     def __init__(self, normalize=True):
         super().__init__(normalize)

--- a/tests/extension/context.py
+++ b/tests/extension/context.py
@@ -5,4 +5,4 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.extended import load_extended_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.extension.sklearn import  TfidfVectorizer, OnlinePipeline # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import  TfidfVectorizer, OnlinePipeline, BM25Vectorizer # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/extension/test_bm25_pipeline.py
+++ b/tests/extension/test_bm25_pipeline.py
@@ -1,0 +1,63 @@
+from .context import load_extended_raw_corpus, BM25Vectorizer, OnlinePipeline, load_raw_corpus
+
+from sklearn.linear_model import SGDClassifier
+from sklearn.pipeline import Pipeline
+from rich.progress import track
+from itertools import tee, islice
+from random import randint
+
+import pytest
+from pytest import raises
+
+BATCH_SIZE = 10
+
+
+def test_pipeline_training():
+    pipeline = Pipeline([('sg_bm25', BM25Vectorizer()),
+                         ('lr', SGDClassifier())])
+
+    X = load_raw_corpus(False)
+    pipeline.fit(X, [randint(0, 1) for _ in range(len(X))])
+
+
+@pytest.mark.skip()
+def test_online_pipeline_training():
+    pipeline = OnlinePipeline([('sg_bm25', BM25Vectorizer()),
+                               ('lr', SGDClassifier())])
+
+    X1, X2 = tee(islice(load_extended_raw_corpus(), 101), 2)
+
+    total = sum(1 for _ in X1)
+
+    batch = []
+    for doc in track(X2, total=total):
+        batch.append(doc)
+
+        if len(batch) == BATCH_SIZE:
+            pipeline.partial_fit(batch, [randint(0, 1) for _ in range(len(batch))], classes=[0, 1])
+
+            batch.clear()
+
+    pipeline.partial_fit(batch, [1 for _ in range(len(batch))])
+
+@pytest.mark.skip()
+def test_online_pipeline_training_divisable_batch():
+    pipeline = OnlinePipeline([('sg_bm25', BM25Vectorizer()),
+                               ('lr', SGDClassifier())])
+
+    X1, X2 = tee(islice(load_extended_raw_corpus(), 100), 2)
+
+    total = sum(1 for _ in X1)
+
+    batch = []
+
+    for doc in track(X2, total=total):
+        batch.append(doc)
+
+        if len(batch) == BATCH_SIZE:
+            pipeline.partial_fit(batch, [randint(0, 1) for _ in range(len(batch))], classes=[0, 1])
+
+            batch.clear()
+
+    with raises(ValueError, match=r"Ensure that X contains at least one valid document.*"):
+        pipeline.partial_fit(batch, [1 for _ in range(len(batch))])

--- a/tests/summarizer/context.py
+++ b/tests/summarizer/context.py
@@ -5,9 +5,10 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.summarize import KMeansSummarizer,AutoKMeansSummarizer,DecomposedKMeansSummarizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.summarize import KMeansSummarizer,AutoKMeansSummarizer,DecomposedKMeansSummarizer, BM25Summarizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.summarize import TextRank  # noqa # pylint: disable=unused-import, wrong
 from sadedegel.summarize import TFIDFSummarizer # noqa # pylint: disable=unused-import
 from sadedegel import Doc, set_config, tokenizer_context # noqa # pylint: disable=unused-import, wrong
 from sadedegel.bblock import BertTokenizer, SimpleTokenizer # noqa # pylint: disable=unused-import, wrong
 from sadedegel.config import tf_context # noqa # pylint: disable=unused-import, wrong
+from sadedegel.dataset import load_raw_corpus # noqa # pylint: disable=unused-import, wrong

--- a/tests/summarizer/test_bm25.py
+++ b/tests/summarizer/test_bm25.py
@@ -1,0 +1,22 @@
+from .context import BM25Summarizer, Doc, tf_context, load_raw_corpus
+import numpy as np
+import pytest
+
+
+@pytest.mark.skip()
+@pytest.mark.parametrize("tf_type, result", [('binary', np.array([0.636, 0.364])),
+                                             ('raw', np.array([0.636, 0.364])),
+                                             ('freq', np.array([0.636, 0.3638])),
+                                             ('log_norm', np.array([0.6357, 0.3638])),
+                                             ('double_norm', np.array([0.636, 0.364]))])
+def test_bm25(tf_type, result):
+    with tf_context(tf_type) as Doc2:
+        d = Doc2("Onu hiç sevmedim. Bu iş çok zor.")
+        assert BM25Summarizer().predict(d) == pytest.approx(result)
+
+
+def test_bm25_corpus():
+    raw = load_raw_corpus()
+    for text in raw:
+        d = Doc(text)
+        assert np.sum(BM25Summarizer().predict(d)) == pytest.approx(1)

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from itertools import product
 from .context import Doc, load_raw_corpus
 
 __famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
@@ -7,7 +8,7 @@ __famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
 
 def test_bm25():
     d = Doc(__famous_quote__)
-    assert np.sum(d[0].bm25()) == pytest.approx(13.99788)
+    assert np.sum(d[0].bm25()) == pytest.approx(13.99788 * len(d[0].tokens)/18.14)
     with pytest.raises(UserWarning, match=r"Out of empirical bounds *."):
         d[0].bm25(k1=0)
 
@@ -18,3 +19,16 @@ def test_bm25_on_corpus():
         d = Doc(text)
         for sent in d:
             assert isinstance(sent.bm25(), np.float32)
+
+
+tfs = ["binary", "raw", "freq", "log_norm", "double_norm"]
+idfs = ["smooth", "probabilistic"]
+
+
+@pytest.mark.parametrize("tf_type, idf_type", product(tfs, idfs))
+def test_get_bm25(tf_type, idf_type):
+    raw = load_raw_corpus()
+    for text in raw:
+        d = Doc(text)
+        for sent in d:
+            assert len(sent.get_bm25(tf_type, idf_type)) == 27744

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from .context import Doc, load_raw_corpus
+
+__famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
+
+
+def test_bm25():
+    d = Doc(__famous_quote__)
+    assert np.sum(d[0].bm25()) == 14.0
+    with pytest.raises(UserWarning, match=r"Out of empirical bounds *."):
+        d[0].bm25(k1=0)
+
+
+def test_bm25_on_corpus():
+    raw = load_raw_corpus()
+    for text in raw:
+        d = Doc(text)
+        for sent in d:
+            assert isinstance(sent.bm25(), np.float16)

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,6 +1,6 @@
+from itertools import product
 import numpy as np
 import pytest
-from itertools import product
 from .context import Doc, load_raw_corpus
 
 __famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
@@ -8,7 +8,7 @@ __famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
 
 def test_bm25():
     d = Doc(__famous_quote__)
-    assert np.sum(d[0].bm25()) == pytest.approx(13.99788 * len(d[0].tokens)/18.14)
+    assert np.sum(d[0].bm25()) == pytest.approx(13.99788 * len(d[0].tokens) / 18.14)
     with pytest.raises(UserWarning, match=r"Out of empirical bounds *."):
         d[0].bm25(k1=0)
 

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -7,7 +7,7 @@ __famous_quote__ = "Merhaba dünya. Biz dostuz. Barış için geldik."
 
 def test_bm25():
     d = Doc(__famous_quote__)
-    assert np.sum(d[0].bm25()) == 14.0
+    assert np.sum(d[0].bm25()) == pytest.approx(13.99788)
     with pytest.raises(UserWarning, match=r"Out of empirical bounds *."):
         d[0].bm25(k1=0)
 
@@ -17,4 +17,4 @@ def test_bm25_on_corpus():
     for text in raw:
         d = Doc(text)
         for sent in d:
-            assert isinstance(sent.bm25(), np.float16)
+            assert isinstance(sent.bm25(), np.float32)


### PR DESCRIPTION
- `BM25Impl` class is implemented like `TFImpl` and `IDFImpl` classes.
- Sentences inherits `BM25Impl` just like `TFImpl` and `IDFImpl`.
- `BM25Impl` makes use of `get_tf` and `get_idf` of other two `..Impl` classes assuming they will all be inherited together by `Sentences`. 
- Factors in bm25 formula are separately implemented as class methods so other `BM` implementations can be incorporated in the future.
- `get_bm25` method returns a vector like `get_tfidf`.
- Just like `get_tfidf` it receives `tf_method`, `idf_method`, `drop_stopwords`, `drop_suffix`, `drop_punct` and `lowercase` arguments. 
- `bm25` method is `rouge1` like and returns score.
- `BM25Summarizer` is implemented with `get_bm25` method.
- `__init__` method receives the arguments of `get_bm25`.
- `tf_method` and `idf_method` are `None` by default. If the user do not specify they are set from config.
- `drop_stopwords`, `drop_suffix`, `drop_punct`, `lowercase`, `k1` and `b` are searched in summarizer evaluation along with `tf_method` and `idf_method`.
- Implement `BM25Vectorizer` influenced from `TFIDFVectorizer`. Uses same arguments with an addition of `k1` and `b` of bm25.