### PR TITLE
Removed redundant space_pad function[resolves #208]

### DIFF
--- a/sadedegel/bblock/util.py
+++ b/sadedegel/bblock/util.py
@@ -24,10 +24,6 @@ def space_pad(token):
     return " " + token + " "
 
 
-def space_pad(token):
-    return " " + token + " "
-
-
 def pad(l, padded_length):
     return l + [0 for _ in range(padded_length - len(l))]
 


### PR DESCRIPTION
- Deleted duplicate&redundant `space_pad` function from `sadedegel.bblock.util.py`.
- This resolves the issue from #208 