### PR TITLE
Add spelling correction module [WIP]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ sadedegel/dataset/sents/*.json filter=lfs diff=lfs merge=lfs -text
 sadedegel/dataset/annotated/*.json filter=lfs diff=lfs merge=lfs -text
 sadedegel/bblock/data/vocabulary.json filter=lfs diff=lfs merge=lfs -text
 sadedegel/prebuilt/model/*.joblib filter=lfs diff=lfs merge=lfs -text
+sadedegel/bblock/data/termfrequency_vocab.txt filter=lfs diff=lfs merge=lfs -text

--- a/sadedegel/bblock/data/termfrequency_vocab.txt
+++ b/sadedegel/bblock/data/termfrequency_vocab.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce309b56ff7e6c4e402b7f83deeec1bbef88b8da919aa5bfd02b88db60c5d9d3
+size 5856610

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -18,7 +18,7 @@ from ..config import load_config
 from .word_tokenizer import WordTokenizer
 from .token import Token, IDF_METHOD_VALUES, IDFImpl
 from ..about import __version__
-
+from . import spelling_corrector
 
 class Span:
     def __init__(self, i: int, span, doc):
@@ -379,6 +379,11 @@ class Document(TFImpl, IDFImpl):
     def tokenizer(self):
         return self.builder.tokenizer
 
+    @property
+    def spelling_corrector(self):
+        return self.builder.spelling_corrector
+
+
     def __getitem__(self, key):
         return self._sents[key]
 
@@ -505,6 +510,11 @@ class Document(TFImpl, IDFImpl):
         return self.builder.from_sentences(sentences)
 
 
+    def get_spell_corrected(self):
+        corrected_sents = self.spelling_corrector.correct_doc(self)
+        return self.builder.from_sentences(corrected_sents)
+
+
 class DocBuilder:
     bert_model = None
 
@@ -515,6 +525,8 @@ class DocBuilder:
         self.sbd = load_model()
 
         self.tokenizer = WordTokenizer.factory(self.config['default']['tokenizer'])
+
+        self.spelling_corrector = spelling_corrector.SpellingCorrector()
 
         idf_method = self.config['idf']['method']
 

--- a/sadedegel/bblock/spelling_corrector.py
+++ b/sadedegel/bblock/spelling_corrector.py
@@ -1,0 +1,89 @@
+import os
+from symspellpy import SymSpell, Verbosity
+from ..bblock import Doc
+
+class SpellingCorrector:
+    DEFAULT_DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "termfrequency_vocab.txt")
+
+    def __init__(self, max_dictionary_edit_distance=2, prefix_length=7, dict_path=None):
+        """Wrapper class for SymSpell which acts as a bridge between
+        Sadedegel and SymSpellPy.
+
+        Args:
+            max_dictionary_edit_distance (str):
+            Maximum edit distance for doing lookups.
+
+            prefix_length (int, optional):
+            The length of word prefixes used for spell checking.
+
+            dict_path (str, optional):
+                Path to a term frequency dictionary of words.
+                If .txt file is passed, then it's assumed every row is in the format
+                of:
+                    [word] [term frequency]
+                if not a .txt file it's assumed to be a pickle file as saved by
+                symspellpy (check symspellpy docs for more info)
+
+                If not passed, loads default provided dictionary.
+
+        """
+
+        self.sym_spell = SymSpell(max_dictionary_edit_distance, prefix_length)
+        self._max_edit_dist = max_dictionary_edit_distance
+        self._dict_loaded = False # lazy loading for dict
+
+        self.dict_path = dict_path
+        if dict_path is None:
+            self.dict_path = self.DEFAULT_DATA_PATH
+
+    def _load_dictionary(self):
+        """Loads the dictionary specified by self.dict_path.
+        Automatically called whenever a spelling is requested and
+        dictionary isn't loaded yet.
+        """
+
+
+        if ".txt" in self.dict_path:
+            is_ok = self.sym_spell.load_dictionary(self.dict_path, 0,1)
+        else:
+            is_ok = self.sym_spell.load_pickle(self.dict_path)
+
+        if not is_ok:
+            raise Exception(f"Could not load spelling dictionary! Dict path: {self.dict_path}")
+
+        self._dict_loaded = True
+
+
+    def correct_compound(self, s):
+        """Given a phrase/sentence correct it and return another corrected string.
+        Uses SymSpellPy's lookup_compound()
+
+        Args:
+            s (str): String to correct
+
+        Returns:
+            str: Corrected string.
+        """
+
+        if not self._dict_loaded:
+            self._load_dictionary()
+
+        suggestions = self.sym_spell.lookup_compound(s, self._max_edit_dist, transfer_casing=True)
+        return suggestions[0]._term
+
+
+    def correct_doc(self, doc):
+        """Given Sadedegel Doc, correct inside text and return a new Doc with the
+        corrected text.
+
+        Args:
+            doc (:obj:`sadedegel.bblock.Doc`): Doc in which text will be corrected
+        """
+
+        res = []
+        for s in doc:
+            res.append(self.correct_compound(str(s)))
+
+        res = " ".join(res)
+
+        return Doc(res)

--- a/sadedegel/bblock/spelling_corrector.py
+++ b/sadedegel/bblock/spelling_corrector.py
@@ -1,6 +1,5 @@
 import os
 from symspellpy import SymSpell, Verbosity
-from ..bblock import Doc
 
 class SpellingCorrector:
     DEFAULT_DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "termfrequency_vocab.txt")
@@ -73,8 +72,9 @@ class SpellingCorrector:
 
 
     def correct_doc(self, doc):
-        """Given Sadedegel Doc, correct inside text and return a new Doc with the
+        """Given Sadedegel Doc, correct inside text and return List[str] with the
         corrected text.
+        (Not returning a new Doc directly as that causes circular import due to Doc import)
 
         Args:
             doc (:obj:`sadedegel.bblock.Doc`): Doc in which text will be corrected
@@ -84,6 +84,5 @@ class SpellingCorrector:
         for s in doc:
             res.append(self.correct_compound(str(s)))
 
-        res = " ".join(res)
 
-        return Doc(res)
+        return res


### PR DESCRIPTION
As title says, added a spelling correction module which utilizes SymSpellPy at the backend and as the vocabulary for spelling correction, approximately 450k~ term frequency vocabulary has been created by merging OpenSubtitles (Turkish) and Turkish Wikipedia data.

Currently only utilizes only one of the possible ways to use SymSpellPy, namely using its `lookup_compound()` method which is not necessarily the best way to correct spelling.

The module is integrated as such:
```python
d = Doc("Ali bubanın çiftliği")
d_fixed = d.get_spell_corrected()
print(d_fixed) # "Ali babanın çiftliği
```

TODO:

- [ ] Add more aggressive/softer methods of spelling correction
- [ ] As a default, load pickled term frequency vocabulary instead of from text (faster loading this way)
- [ ] Notify user when the dictionary is being loaded (as it takes a few seconds)
- [ ] Keep term frequency vocabulary in a bucket instead of LFS?
- [ ] Customizable spelling correction (configs/overriding spelling correction class?)
- [ ] Test its performance on dataset shown below and find decent default parameters
- [ ] Unit tests !

Dataset to test on:
https://github.com/StarlangSoftware/Dictionary/blob/master/src/main/resources/turkish_misspellings.txt