### PR TITLE
BERT Token Weighting [resolves #163]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -442,7 +442,10 @@ class Document(TFImpl, IDFImpl):
 
             twelve_layers = outputs[2][1:]
 
-            self._bert = select_layer(twelve_layers, [11], return_cls=False, weighting=weighting)
+            if weighting is None:
+                self._bert = select_layer(twelve_layers, [11], return_cls=False)
+            else:
+                self._bert = select_layer(twelve_layers, [11], return_cls=False, weighting=weighting, sents=self)
 
         return self._bert
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -425,7 +425,7 @@ class Document(TFImpl, IDFImpl):
                 return mat
 
     @property
-    def bert_embeddings(self):
+    def bert_embeddings(self, weighting=None):
         if self._bert is None:
             inp, mask = self.padded_matrix()
 
@@ -442,7 +442,7 @@ class Document(TFImpl, IDFImpl):
 
             twelve_layers = outputs[2][1:]
 
-            self._bert = select_layer(twelve_layers, [11], return_cls=False)
+            self._bert = select_layer(twelve_layers, [11], return_cls=False, weighting=weighting)
 
         return self._bert
 

--- a/sadedegel/bblock/util.py
+++ b/sadedegel/bblock/util.py
@@ -149,7 +149,7 @@ def select_layer(bert_out: tuple, layers: List[int], return_cls: bool, weighting
                         tfidf_of_tokens = tfidf_of_sents[s]
                         tokens = sents[s].tokens
                         len_tokens = len(tokens)
-                        print(len_tokens)
+
                         for t, token in enumerate(sentence[1:-1]):  # Exclude [CLS] and [SEP] embeddings
                             if t > len_tokens - 1:
                                 continue


### PR DESCRIPTION
- Current `bert_embeddings` for each sentence are generated by unweighted mean of tokens.
- Weight token embeddings with `tfidf` values of the tokens.
- Implement this in `select_layer` utility function.
- `bert_embeddings` property has `weighting` argument. Turn this into a config in the future.
- @ertugrul-dmr please add tests to complete PR.

**Important Remark:** `select_layer` is obsolete. A new utility function for layerwise token -> sentence -> document embedding creation is needed. Should also incorporate token and sentence weightings for sentence embedding and doc embedding generation respectively. Will open an issue on it.