### PR TITLE
Add specific directories of datasets to skipif conditions in sadedegel.dataset tests [resolves #220]

### DIFF
--- a/tests/datasets/test_extended_corpus.py
+++ b/tests/datasets/test_extended_corpus.py
@@ -4,7 +4,7 @@ from os.path import expanduser  # pylint: disable=unused-import
 from .context import load_extended_metadata, load_extended_raw_corpus, load_extended_sents_corpus
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/extended")).exists()')
 def test_metadata():
     md = load_extended_metadata()
 
@@ -13,7 +13,7 @@ def test_metadata():
     assert md['count']['raw'] == 36131
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/extended")).exists()')
 def test_raw():
     raw = load_extended_raw_corpus()
 

--- a/tests/datasets/test_tscorpus.py
+++ b/tests/datasets/test_tscorpus.py
@@ -8,21 +8,21 @@ from .context import check_and_display, load_tokenization_raw, load_tokenization
     tok_eval
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/tscorpus")).exists()')
 def test_raw():
     raw = load_tokenization_raw()
 
     assert sum(1 for _ in raw) == CORPUS_SIZE
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/tscorpus")).exists()')
 def test_tokenized():
     tokenized = load_tokenization_tokenized()
 
     assert sum(1 for _ in tokenized) == CORPUS_SIZE
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/tscorpus")).exists()')
 def test_metadata():
     stats = check_and_display("~/.sadedegel_data")
 
@@ -30,7 +30,7 @@ def test_metadata():
     assert stats['byte']['raw'] * 1e6 >= 1 * 1024 * 1024
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/tscorpus")).exists()')
 def test_evaluator():
     table = tok_eval(["simple", "bert"], limit=1000)
 

--- a/tests/datasets/test_tweet_sentiment.py
+++ b/tests/datasets/test_tweet_sentiment.py
@@ -6,7 +6,7 @@ import pytest
 from .context import load_tweet_sentiment_train, CLASS_VALUES
 
 
-@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
+@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/tweet_sentiment")).exists()')
 def test_data_load():
     data = load_tweet_sentiment_train()
     for i, row in enumerate(data):


### PR DESCRIPTION
- If a developer has downloaded any one of the non-publicly available corpuses the tests for the rest will start to fail because `skipif` condition only checks for the existence of root directory not the specific dataset directory.
- This forces the developer to download rest of the corpuses even if they are not necessary.
- I added ```@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data/<dataset_name>")).exists()')``` to relevant tests.