### PR TITLE
Fix tscorpus evaluator test

### DIFF
--- a/tests/datasets/test_tscorpus.py
+++ b/tests/datasets/test_tscorpus.py
@@ -31,10 +31,13 @@ def test_metadata():
 
 
 @pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
-def test_evaluator():
-    table = tok_eval(["simple", "bert"], limit=1000)
+@pytest.mark.parametrize("tokenizer", ["simple", "bert"])
+def test_evaluator(tokenizer):
+    table = tok_eval(tokenizer, 1000)
 
-    assert float(table[0][1]) > 0.83
-    assert float(table[0][2]) > 0.83
-    assert float(table[1][1]) > 0.86
-    assert float(table[1][2]) > 0.86
+    if table[0] == 'simple':
+        assert float(table[1]) > 0.83
+        assert float(table[2]) > 0.83
+    elif table[0] == 'bert':
+        assert float(table[1]) > 0.86
+        assert float(table[2]) > 0.86


### PR DESCRIPTION
- Current `tests/datasets/test_tscorpus.py` in develop 57738ef has this assertion error.
```shell
tests/datasets/test_tscorpus.py:32 (test_evaluator)
@pytest.mark.skipif('not Path(expanduser("~/.sadedegel_data")).exists()')
    def test_evaluator():
        table = tok_eval(["simple", "bert"], limit=1000)
    
>       assert float(table[0][1]) > 0.83
E       ValueError: could not convert string to float: 'bert'

```

The reason in `tok_eval` does not return a table. `tokenizer_evaluate` CLI command returns a table and that method uses `tok_eval` in a loop in `sadedegel/bblock/cli/__main__.py`.

- I fixed tests based on returned tuple from `tok_eval`.