### PR TITLE
Fix load of serialized models [resolves #233]

### DIFF
--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -36,8 +36,11 @@ class Text2Doc(BaseEstimator, TransformerMixin):
         self.tokenizer = tokenizer
         # TODO: Add sadedegel version
 
+        self.init()
+
+    def init(self):
         if Text2Doc.Doc is None:
-            Text2Doc.Doc = DocBuilder(tokenizer=tokenizer)
+            Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer)
 
     def fit(self, X, y=None):
         return self

--- a/sadedegel/prebuilt/news_classification.py
+++ b/sadedegel/prebuilt/news_classification.py
@@ -74,7 +74,11 @@ def build(max_rows=-1, batch_size=10000):
 
 
 def load(model_name="news_classification"):
-    return jl_load(Path(dirname(__file__)) / 'model' / f"{model_name}.joblib")
+    pipeline = jl_load(Path(dirname(__file__)) / 'model' / f"{model_name}.joblib")
+
+    pipeline.steps[0][1].init()
+
+    return pipeline
 
 
 if __name__ == '__main__':

--- a/sadedegel/prebuilt/tweet_profanity.py
+++ b/sadedegel/prebuilt/tweet_profanity.py
@@ -65,7 +65,11 @@ def build(save=True):
 
 
 def load():
-    return jl_load(Path(dirname(__file__)) / 'model' / 'tweet_profanity_classification.joblib')
+    pipeline = jl_load(Path(dirname(__file__)) / 'model' / 'tweet_profanity_classification.joblib')
+
+    pipeline.steps[0][1].init()
+
+    return pipeline
 
 
 def evaluate(model=None):

--- a/sadedegel/prebuilt/tweet_sentiment.py
+++ b/sadedegel/prebuilt/tweet_sentiment.py
@@ -112,7 +112,11 @@ def build(max_instances=-1, save=True):
 
 
 def load(model_name="tweet_sentiment"):
-    return jl_load(Path(dirname(__file__)) / 'model' / f"{model_name}.joblib")
+    pipeline = jl_load(Path(dirname(__file__)) / 'model' / f"{model_name}.joblib")
+
+    pipeline.steps[0][1].init()
+
+    return pipeline
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Implement an `init()` method in `Text2Doc` to invoke after loading a pipeline.
- Invoke `init()` of `Text2Doc` in prebuilt pipelines' load methods.