### PR TITLE
Implement Pre-Built Customer Reviews Classifier Model [resolves #232]

### DIFF
--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -133,6 +133,7 @@ Classifier assigns each Turkish customer review text into 32 classes by using sa
 
 ```python
 from sadedegel.prebuilt import customer_reviews_classification
+
 # We load our prebuilt model:
 model = customer_reviews_classification.load()
 
@@ -144,7 +145,16 @@ y_probs = model.predict_proba(['odalar çok kirliydi'])
 
 # You can check original test results on holdout set:
 customer_reviews_classification.evaluate()
+
+# You convert class id's back to labels by importing:
+from sadedegel.dataset.customer_review import CLASS_VALUES
+
+# And simply map them to get the converted string list:
+y_pred_label = [CLASS_VALUES[idx] for idx in y_pred]
 ```
 
 #### Accuracy
-Current prebuilt customer review classification model has a macro-F1 score of 0.851 on holdout test set model never seen before.
+Current prebuilt customer review classification model has a macro-F1 score of `0.851` on holdout test set model never seen before.
+
+If you want to compare benchmark results:
+> The model on [Kaggle](https://www.kaggle.com/savasy/multiclass-classification-data-for-turkish-tc32) where we got dataset from has F1 score of `0.84`.

--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -100,3 +100,27 @@ movie_reviews.evaluate()
 #### Accuracy
 
 * Current prebuilt movie review model has a **macro-F1** score of `0.825` on holdout test set model never seen before.
+
+### Turkish Customer Reviews Classification
+
+Classifier assigns each Turkish customer review text into 32 classes by using sadedegel built-in pipeline.
+
+#### Loading and Predicting with the Model:
+
+```python
+from sadedegel.prebuilt import customer_reviews_classification
+# We load our prebuilt model:
+model = customer_reviews_classification.load()
+
+# Here we feed our text to get predictions:
+y_pred = model.predict(['odalar çok kirliydi'])
+
+# You can also get probabilities with:
+y_probs = model.predict_proba(['odalar çok kirliydi'])
+
+# You can check original test results on holdout set:
+customer_reviews_classification.evaluate()
+```
+
+#### Accuracy
+Current prebuilt customer review classification model has a macro-F1 score of 0.851 on holdout test set model never seen before.

--- a/sadedegel/prebuilt/customer_reviews_classification.py
+++ b/sadedegel/prebuilt/customer_reviews_classification.py
@@ -1,0 +1,82 @@
+from math import ceil
+from pathlib import Path
+from os.path import dirname
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.utils import shuffle
+from sklearn.metrics import f1_score, roc_auc_score
+from sklearn.pipeline import Pipeline
+
+
+from rich.console import Console
+
+from joblib import dump
+
+import numpy as np
+
+from ..extension.sklearn import TfidfVectorizer, Text2Doc
+from .util import load_model
+
+console = Console()
+
+def empty_model():
+    return Pipeline(
+        [('text2doc', Text2Doc('icu')),
+         ('tfidf', TfidfVectorizer(tf_method='log_norm', idf_method='probabilistic', drop_punct=True,
+                                   lowercase=True, show_progress=True)),
+         ('logreg', LogisticRegression(penalty='l2', C=0.02987625339246147, fit_intercept=False, solver='liblinear'))
+         ]
+    )
+
+def build(max_rows=-1, save=True):
+    try:
+        import pandas as pd
+    except ImportError:
+        console.log(("pandas package is not a general sadedegel dependency."
+                     " But we do have a dependency on building our prebuilt models"))
+
+    df = pd.read_csv(Path(dirname(__file__)) /  'customer_reviews_train.csv')
+    df = shuffle(df, random_state=42)
+
+    if max_rows > 0:
+        df = df.sample(max_rows, random_state=42)
+
+    pipeline = empty_model()
+
+    pipeline.fit(df.text, df.review_class)
+
+    if save:
+        model_dir = Path(dirname(__file__)) / 'model'
+
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        pipeline.steps[0][1].Doc = None
+
+        dump(pipeline, (model_dir / 'customer_review_classification.joblib').absolute(), compress=('gzip', 9))
+
+    evaluate(pipeline)
+
+    console.log('Model build [green]DONE[/green]')
+
+def load(model_name='customer_review_classification'):
+    return load_model(model_name)
+
+def evaluate(model=None, scoring='f1'):
+    try:
+        import pandas as pd
+    except ImportError:
+        console.log(("pandas package is not a general sadedegel dependency."
+                     " But we do have a dependency on building our prebuilt models"))
+    model  = load()
+
+    test = pd.read_csv(Path(dirname(__file__)) /  'customer_reviews_test.csv')
+    if scoring=='f1':
+        y_pred = model.predict(test.text)
+        console.log(f"Model test accuracy (f1-macro): {f1_score(test.review_class, y_pred, average='macro')}")
+    if scoring=='auc':
+        y_pred = model.predict_proba(test.text)
+        console.log(f"Model test roc_auc score: {roc_auc_score(test.review_class, y_pred, multi_class='ovr')}")
+
+
+if __name__ == "__main__":
+    build(save=True)

--- a/sadedegel/prebuilt/customer_reviews_classification.py
+++ b/sadedegel/prebuilt/customer_reviews_classification.py
@@ -1,4 +1,3 @@
-from math import ceil
 from pathlib import Path
 from os.path import dirname
 
@@ -12,10 +11,10 @@ from rich.console import Console
 
 from joblib import dump
 
-import numpy as np
-
 from ..extension.sklearn import TfidfVectorizer, Text2Doc
 from .util import load_model
+
+# gonna add dataset paths
 
 console = Console()
 
@@ -34,7 +33,7 @@ def build(max_rows=-1, save=True):
     except ImportError:
         console.log(("pandas package is not a general sadedegel dependency."
                      " But we do have a dependency on building our prebuilt models"))
-
+    # gonna add updated paths
     df = pd.read_csv(Path(dirname(__file__)) /  'customer_reviews_train.csv')
     df = shuffle(df, random_state=42)
 
@@ -69,6 +68,7 @@ def evaluate(model=None, scoring='f1'):
                      " But we do have a dependency on building our prebuilt models"))
     model  = load()
 
+    # gonna add updated paths
     test = pd.read_csv(Path(dirname(__file__)) /  'customer_reviews_test.csv')
     if scoring=='f1':
         y_pred = model.predict(test.text)

--- a/sadedegel/prebuilt/model/customer_review_classification.joblib
+++ b/sadedegel/prebuilt/model/customer_review_classification.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eaa49b33373fa41e2512892747a3a778bca561d8f75afcb003a498b29876a36
+size 12102106

--- a/tests/prebuilt/context.py
+++ b/tests/prebuilt/context.py
@@ -11,4 +11,4 @@ from sadedegel.prebuilt import tweet_sentiment , movie_reviews, customer_reviews
 from sadedegel.dataset.tweet_sentiment import CLASS_VALUES as SENTIMENT_VALUES  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.movie_sentiment import CLASS_VALUES as SENTIMENT_VALUES_M  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.telco_sentiment import CLASS_VALUES as SENTIMENT_VALUES_T  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.dataset.customer_review_classification import CLASS_VALUES as CLASS_VALUES_CUST # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset.customer_review import CLASS_VALUES as CLASS_VALUES_CUST # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/prebuilt/context.py
+++ b/tests/prebuilt/context.py
@@ -10,4 +10,4 @@ from sadedegel.dataset.profanity import CLASS_VALUES # noqa # pylint: disable=un
 from sadedegel.prebuilt import tweet_sentiment , movie_reviews, customer_reviews_classification # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tweet_sentiment import CLASS_VALUES as SENTIMENT_VALUES  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.movie_sentiment import CLASS_VALUES as SENTIMENT_VALUES_M  # noqa # pylint: disable=unused-import, wrong-import-position
-
+from sadedegel.dataset.customer_review_classification import CLASS_VALUES as CLASS_VALUES_CUST # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/prebuilt/context.py
+++ b/tests/prebuilt/context.py
@@ -7,7 +7,7 @@ from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-i
 from sadedegel.prebuilt import news_classification, tweet_profanity  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tscorpus import CATEGORIES # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.profanity import CLASS_VALUES # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.prebuilt import tweet_sentiment , movie_reviews # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.prebuilt import tweet_sentiment , movie_reviews, customer_reviews_classification # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tweet_sentiment import CLASS_VALUES as SENTIMENT_VALUES  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.movie_sentiment import CLASS_VALUES as SENTIMENT_VALUES_M  # noqa # pylint: disable=unused-import, wrong-import-position
 

--- a/tests/prebuilt/test_customer_reviews.py
+++ b/tests/prebuilt/test_customer_reviews.py
@@ -1,12 +1,13 @@
 from .context import customer_reviews_classification
 
+# going to add dataset path
 
 def test_model_load():
     model = customer_reviews_classification.load()
     pred_hotel = model.predict(['odalar çok kirliydi'])
     pred_pc = model.predict(['ram çok düşük'])
 
-    assert pred_hotel[0] == 30
+    assert pred_hotel[0] == 30 # gonna use class values
     assert pred_pc[0] == 3
 
     prob_hotel = model.predict_proba(['odalar çok kirliydi'])

--- a/tests/prebuilt/test_customer_reviews.py
+++ b/tests/prebuilt/test_customer_reviews.py
@@ -5,8 +5,8 @@ def test_model_load():
     pred_hotel = model.predict(['odalar çok kirliydi'])
     pred_pc = model.predict(['ram çok düşük'])
 
-    assert CLASS_VALUES_CUST[pred_hotel[0]] == 'turizm'
-    assert CLASS_VALUES_CUST[pred_pc[0]] == 'bilgisayar'
+    assert CLASS_VALUES_CUST[pred_hotel[0]] == 'Turizm'
+    assert CLASS_VALUES_CUST[pred_pc[0]] == 'Bilgisayar'
 
     prob_hotel = model.predict_proba(['odalar çok kirliydi'])
 

--- a/tests/prebuilt/test_customer_reviews.py
+++ b/tests/prebuilt/test_customer_reviews.py
@@ -1,0 +1,15 @@
+from .context import customer_reviews_classification
+
+
+def test_model_load():
+    model = customer_reviews_classification.load()
+    pred_hotel = model.predict(['odalar çok kirliydi'])
+    pred_pc = model.predict(['ram çok düşük'])
+
+    assert pred_hotel[0] == 30
+    assert pred_pc[0] == 3
+
+    prob_hotel = model.predict_proba(['odalar çok kirliydi'])
+
+    assert prob_hotel[0][30] == prob_hotel[0].max()
+    assert prob_hotel.shape == (1, 32)

--- a/tests/prebuilt/test_customer_reviews.py
+++ b/tests/prebuilt/test_customer_reviews.py
@@ -1,14 +1,12 @@
-from .context import customer_reviews_classification
-
-# going to add dataset path
+from .context import customer_reviews_classification, CLASS_VALUES_CUST
 
 def test_model_load():
     model = customer_reviews_classification.load()
     pred_hotel = model.predict(['odalar çok kirliydi'])
     pred_pc = model.predict(['ram çok düşük'])
 
-    assert pred_hotel[0] == 30 # gonna use class values
-    assert pred_pc[0] == 3
+    assert CLASS_VALUES_CUST[pred_hotel[0]] == 'turizm'
+    assert CLASS_VALUES_CUST[pred_pc[0]] == 'bilgisayar'
 
     prob_hotel = model.predict_proba(['odalar çok kirliydi'])
 


### PR DESCRIPTION
`sadedegel/prebuilt/README.md:`

- Added how to use prebuilt pipeline
- Added how to use evaluation
- Added holdout test set f-1 macro score

`sadedegel/prebuilt/model/customer_review_classification.joblib:`

- Dumped pretrained/optimized model weights

`sadedegel/prebuilt/customer_reviews_classification.py:`

- Updated functions according to CONTRIBUTING.md
- Added, build, load and evaluate functions
- Added option to check roc_auc score for predict_proba method
- Model and vectorizer parameters are selected using optimizer with 3 fold results for 50 combinations

`tests/prebuilt/context.py:`

- Added import line for the base model

`tests/prebuilt/test_movie_review_sentiment.py:`

- Added assertions for testing purposes.

### To-do:

- Going to update data paths for sadedegel dataset imports when they're available. (Self note, clean the reminder comments after that) 
