### PR TITLE
Telco Sentiment Prebuilt Implementation

### DIFF
--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -117,4 +117,10 @@ telco_sentiment.evaluate()
 
 #### Accuracy
 
-* Current prebuilt telco sentiment model has a **macro-F1** score of `0.6844` on holdout test set model never seen before. The open source [benchmark](https://ieeexplore.ieee.org/document/8554037/) best score on the hold-out set is `0.6925`. Please contact sadedegel team for better performing models. 
+Current prebuilt open source telco sentiment model has a **macro-F1** score of `0.6844` on holdout test set model never seen before. 
+
+Comparable [benchmark](https://ieeexplore.ieee.org/document/8554037/) models has  
+* `0.6925` **macro-F1** score (convolutional neural networks fed with char ngrams)
+* `0.66` **macro-F1** score (classical ML approach fed with bag-of-words)
+on the hold-out set.
+

--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -97,6 +97,24 @@ y_pred = model.predict(['süper aksiyon, tavsiye ederim'])
 movie_reviews.evaluate()
 ```
 
+### Telco Brand Tweet Sentiment Classification
+
+Classifier assigns each tweet mentioning the telecom brand into three classes ('olumlu', olumsuz', 'notr') by using sadedegel built-in pipeline.
+
+#### Loading and Predicting with the Model:
+
+```python
+from sadedegel.prebuilt import telco_sentiment
+# We load our prebuilt model:
+model = telco_sentiment.load()
+
+# Here we feed our text to get predictions:
+y_pred = model.predict(['Magma tabakasından bile çekiyor helal olsun valla.'])
+
+# You can check original test results on holdout set:
+telco_sentiment.evaluate()
+```
+
 #### Accuracy
 
-* Current prebuilt movie review model has a **macro-F1** score of `0.825` on holdout test set model never seen before.
+* Current prebuilt telco sentiment model has a **macro-F1** score of `0.6844` on holdout test set model never seen before. The open source [benchmark](https://ieeexplore.ieee.org/document/8554037/) best score on the hold-out set is `0.6925`. Please contact sadedegel team for better performing models. 

--- a/sadedegel/prebuilt/model/telco_sentiment_classification.joblib
+++ b/sadedegel/prebuilt/model/telco_sentiment_classification.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad537d888c6f8ab57c6e0b01fa139120dde7dff82d097e46f83ac93bd231dfae
+size 664112

--- a/sadedegel/prebuilt/telco_sentiment.py
+++ b/sadedegel/prebuilt/telco_sentiment.py
@@ -1,0 +1,85 @@
+from os.path import dirname
+from pathlib import Path
+
+from joblib import dump
+from rich.console import Console
+from sklearn.metrics import f1_score
+from sklearn.pipeline import Pipeline, FeatureUnion
+from sklearn.svm import SVC
+from sklearn.utils import shuffle
+
+from .util import load_model
+from ..dataset.telco_sentiment import load_telco_sentiment_train, load_telco_sentiment_test, \
+    load_telco_sentiment_target, CORPUS_SIZE
+from ..extension.sklearn import HashVectorizer, Text2Doc
+
+console = Console()
+
+
+def empty_model():
+    return Pipeline(
+        [('text2doc', Text2Doc("icu")),
+         ('hash', HashVectorizer(n_features=496485, alternate_sign=True)),
+         ('svc', SVC(C=0.3184661147229449, kernel="linear", verbose=True, random_state=42, probability=True))]
+    )
+
+
+def build(save=True):
+    try:
+        import pandas as pd
+    except ImportError:
+        console.log(("pandas package is not a general sadedegel dependency."
+                     " But we do have a dependency on building our prebuilt models"))
+
+    raw = load_telco_sentiment_train()
+    df = pd.DataFrame.from_records(raw)
+    df = shuffle(df)
+
+    console.log(f"Corpus Size: {CORPUS_SIZE}")
+
+    pipeline = empty_model()
+
+    pipeline.fit(df.tweet, df.sentiment_class)
+
+    evaluate(pipeline)
+
+    console.log("Model build [green]DONE[/green]")
+
+    if save:
+        model_dir = Path(dirname(__file__)) / 'model'
+
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        pipeline.steps[0][1].Doc = None
+
+        dump(pipeline, (model_dir / 'telco_sentiment_classification.joblib').absolute(), compress=('gzip', 9))
+
+        console.log("Model save [green]DONE[/green]")
+
+
+def load(model_name="telco_sentiment_classification"):
+    return load_model(model_name)
+
+
+def evaluate(model=None):
+    try:
+        import pandas as pd
+    except ImportError:
+        console.log(("pandas package is not a general sadedegel dependency."
+                     " But we do have a dependency on building our prebuilt models"))
+
+    if model is None:
+        model = load()
+
+    test = pd.DataFrame.from_records(load_telco_sentiment_test())
+    testLabel = pd.DataFrame.from_records(load_telco_sentiment_target())
+
+    test = test.merge(testLabel, on='id')
+
+    y_pred = model.predict(test.tweet)
+
+    console.log(f"Model test accuracy (f1-macro): {f1_score(test.sentiment_class, y_pred, average='macro')}")
+
+
+if __name__ == "__main__":
+    build(save=True)

--- a/sadedegel/prebuilt/telco_sentiment.py
+++ b/sadedegel/prebuilt/telco_sentiment.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from joblib import dump
 from rich.console import Console
 from sklearn.metrics import f1_score
-from sklearn.pipeline import Pipeline, FeatureUnion
+from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC
 from sklearn.utils import shuffle
 

--- a/tests/prebuilt/context.py
+++ b/tests/prebuilt/context.py
@@ -4,10 +4,10 @@ from pathlib import Path
 sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.prebuilt import news_classification, tweet_profanity  # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.prebuilt import news_classification, tweet_profanity, telco_sentiment  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tscorpus import CATEGORIES # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.profanity import CLASS_VALUES # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.prebuilt import tweet_sentiment , movie_reviews # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.tweet_sentiment import CLASS_VALUES as SENTIMENT_VALUES  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.movie_sentiment import CLASS_VALUES as SENTIMENT_VALUES_M  # noqa # pylint: disable=unused-import, wrong-import-position
-
+from sadedegel.dataset.telco_sentiment import CLASS_VALUES as SENTIMENT_VALUES_T  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/prebuilt/test_telco_sentiment.py
+++ b/tests/prebuilt/test_telco_sentiment.py
@@ -3,17 +3,17 @@ from .context import telco_sentiment, SENTIMENT_VALUES_T
 
 def test_model_load():
     pipeline = telco_sentiment.load()
-    assert True
+    assert pipeline is not None
 
 
 def test_inference():
     model = telco_sentiment.load()
 
-    pred = model.predict(['turkcell en iyi operatör.', 'burada hala çekmiyor amk.'])
+    pred = model.predict(['turkcell en iyi operatör.', 'burada hala çekmiyor.'])
 
     assert SENTIMENT_VALUES_T[pred[0]] in SENTIMENT_VALUES_T
     assert SENTIMENT_VALUES_T[pred[1]] in SENTIMENT_VALUES_T
 
-    probability = model.predict_proba(['turkcell en iyi operatör.', 'burada hala çekmiyor amk.'])
+    probability = model.predict_proba(['turkcell en iyi operatör.', 'burada hala çekmiyor.'])
 
     assert probability.shape == (2, 3)

--- a/tests/prebuilt/test_telco_sentiment.py
+++ b/tests/prebuilt/test_telco_sentiment.py
@@ -1,0 +1,19 @@
+from .context import telco_sentiment, SENTIMENT_VALUES_T
+
+
+def test_model_load():
+    pipeline = telco_sentiment.load()
+    assert True
+
+
+def test_inference():
+    model = telco_sentiment.load()
+
+    pred = model.predict(['turkcell en iyi operatör.', 'burada hala çekmiyor amk.'])
+
+    assert SENTIMENT_VALUES_T[pred[0]] in SENTIMENT_VALUES_T
+    assert SENTIMENT_VALUES_T[pred[1]] in SENTIMENT_VALUES_T
+
+    probability = model.predict_proba(['turkcell en iyi operatör.', 'burada hala çekmiyor amk.'])
+
+    assert probability.shape == (2, 3)


### PR DESCRIPTION
- Implement prebuilt model with telco sentiment dataset.
- Benchmark F1score in paper is `0.6925` with convolutional neural networks fed with char ngrams.
- Benchmark Bag-of-words classic ML approach in paper has `0.66` F1 in the paper.
- SadedeGel prebuilt classic ML approach `0.6844`.
- Let's discuss whether we will host benchmark passing model here or not.  
- Scores documented addresses @husnusensoy's question in #240.