### PR TITLE
Fix telco_sentiment/__main__py

### DIFF
--- a/sadedegel/dataset/telco_sentiment/__main__.py
+++ b/sadedegel/dataset/telco_sentiment/__main__.py
@@ -75,8 +75,8 @@ def validate():
             sys.exit(1)
 
     with console.status("[bold yellow]Validate test"):
-        test = set((d['text_uuid'] for d in load_telco_sentiment_test()))
-        test_label = set((d['text_uuid'] for d in load_telco_sentiment_target()))
+        test = set((d['id'] for d in load_telco_sentiment_test()))
+        test_label = set((d['id'] for d in load_telco_sentiment_test_label()))
 
         a_b, ab, b_a = test - test_label, test & test_label, test_label - test
 

--- a/sadedegel/dataset/telco_sentiment/__main__.py
+++ b/sadedegel/dataset/telco_sentiment/__main__.py
@@ -11,7 +11,7 @@ import boto3
 
 from loguru import logger
 
-from ._core import load_telco_sentiment_target, load_telco_sentiment_train, \
+from ._core import load_telco_sentiment_test_label, load_telco_sentiment_train, \
                    load_telco_sentiment_test, CORPUS_SIZE, CLASS_VALUES
 
 from zipfile import ZipFile


### PR DESCRIPTION
There were typo errors in `__main__.py` which do not affect model building but raises errors when data is tried to be validated.
- `_target` was not standardized into `_test_label` in import statement.
- `text_uuid` should be `id` as it is in the csv to iterator mapping. 