### PR TITLE
Implement Prefix Range as Hyperparam of HashVectorizer [resolves #262]

### DIFF
--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -88,9 +88,10 @@ class SadedegelVectorizer(BaseEstimator, TransformerMixin):
 
 
 class HashVectorizer(BaseEstimator, TransformerMixin):
-    def __init__(self, n_features=1048576, *, alternate_sign=True):
+    def __init__(self, n_features=1048576, prefix_range=[3, 5], *, alternate_sign=True):
         self.n_features = n_features
         self.alternate_sign = alternate_sign
+        self.prefix_range = prefix_range
 
     def fit(self, X, y=None):
         return self
@@ -99,10 +100,13 @@ class HashVectorizer(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, docs):
+        range_iter = self.prefix_range
+        if isinstance(self.prefix_range, tuple):
+            range_iter = range(self.prefix_range[0], self.prefix_range[1] + 1)
+
         def feature_iter():
             for d in docs:
-                yield [('prefix5', t.lower_[:5]) for t in d.tokens] + [('prefix3', t.lower_[:3]) for t in
-                                                                       d.tokens]
+                yield [(f'prefix{p_ix}', t.lower_[:p_ix]) for p_ix in range_iter for t in d.tokens]
 
         return FeatureHasher(self.n_features, alternate_sign=self.alternate_sign, input_type="pair",
                              dtype=np.float32).transform(feature_iter())

--- a/tests/extension/context.py
+++ b/tests/extension/context.py
@@ -5,5 +5,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.extended import load_extended_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.extension.sklearn import  Text2Doc, TfidfVectorizer, OnlinePipeline, BM25Vectorizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import  Text2Doc, TfidfVectorizer, OnlinePipeline, BM25Vectorizer, HashVectorizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset.tweet_sentiment import load_tweet_sentiment_train # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.config import tokenizer_context # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/extension/test_hashv.py
+++ b/tests/extension/test_hashv.py
@@ -1,0 +1,18 @@
+from sklearn.pipeline import Pipeline
+import pytest
+from itertools import product
+import pandas as pd
+from .context import HashVectorizer, Text2Doc, load_tweet_sentiment_train
+
+p = product(["icu", "simple", "bert"], [(1, 3), [2, 5], (3, 8), [3, 6]], [True, False])
+
+
+@pytest.mark.parametrize("tokenizer, prefix_range, alternate_sign", p)
+def test_hashvect(tokenizer, prefix_range, alternate_sign):
+    feng_pipeline = Pipeline([("Text2Doc", Text2Doc(tokenizer=tokenizer)),
+                              ("HashVec", HashVectorizer(prefix_range=prefix_range,
+                                                         alternate_sign=alternate_sign))])
+
+    df = pd.DataFrame().from_records(load_tweet_sentiment_train()).sample(10, random_state=42)
+
+    assert feng_pipeline.fit_transform(df["tweet"]).shape[0] == len(df)


### PR DESCRIPTION
- `prefix_range` in constructor can get two types of input:
   - `List[int]` for specifying distinct amount. e.g. `[3, 5]` will produce `prefix3` and `prefix5`
   - `tuple(int)` for specifying a range. e.g. `(2,4)` will produce `prefix2`, `prefix3`, `prefix4`
- Implement tests for the vectorizer in difference range, tokenizer and alternate_sign flag combinations.
- **Important Note** in order for serialized prebuilt models to work with this version of transformer, pipelines that use `HashVectorizer` should be retrained and dumped.
  - Using `[3, 5]` to keep current scores.
  - Or optimize again searching for prefix ranges. 