### PR TITLE
Implement CharNGram Based HashVectorizer

### DIFF
--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -87,6 +87,29 @@ class SadedegelVectorizer(BaseEstimator, TransformerMixin):
         return self
 
 
+class CharHashVectorizer(BaseEstimator, TransformerMixin):
+    def __init__(self, n_features=1048576, ngram_range=(1, 1), *, alternate_sign=True):
+        self.n_features = n_features
+        self.ngram_range = ngram_range
+        self.alternate_sign = alternate_sign
+
+    def fit(self, X, y=None):
+        return self
+
+    def partial_fit(self, X, y=None, **kwargs):
+        return self
+
+    def transform(self, docs):
+        range_iter = range(self.ngram_range[0], self.ngram_range[1] + 1)
+
+        def feature_iter():
+            for d in docs:
+                yield [(f"{ngram}gram", t.lower_[i:i+ngram]) for ngram in range_iter for t in d.tokens for i in range(len(t.word)) if len(t.lower_[i:i+ngram]) == ngram]
+
+        return FeatureHasher(self.n_features, alternate_sign=self.alternate_sign, input_type="pair",
+                             dtype=np.float32).transform(feature_iter())
+
+
 class HashVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, n_features=1048576, *, alternate_sign=True):
         self.n_features = n_features

--- a/tests/extension/context.py
+++ b/tests/extension/context.py
@@ -5,5 +5,6 @@ sys.path.insert(0, (Path(__file__) / '..' / '..').absolute())
 
 from sadedegel.dataset import load_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.dataset.extended import load_extended_raw_corpus  # noqa # pylint: disable=unused-import, wrong-import-position
-from sadedegel.extension.sklearn import  Text2Doc, TfidfVectorizer, OnlinePipeline, BM25Vectorizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import  Text2Doc, TfidfVectorizer, OnlinePipeline, BM25Vectorizer, CharHashVectorizer # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.config import tokenizer_context # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.dataset.tweet_sentiment import load_tweet_sentiment_train # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/extension/test_char_hash_vec.py
+++ b/tests/extension/test_char_hash_vec.py
@@ -1,0 +1,19 @@
+from itertools import product
+import pytest
+from sklearn.pipeline import Pipeline
+import pandas as pd
+
+from .context import CharHashVectorizer, Text2Doc, load_tweet_sentiment_train
+
+d = product(["icu", "simple", "bert"], [(1, 1), (1, 3), (3, 6), (4, 7)], [True, False])
+
+
+@pytest.mark.parametrize("tokenizer, ngram_range, alternate_sign", d)
+def test_char_hash_vec(tokenizer, ngram_range, alternate_sign):
+    feng_pipeline = Pipeline([("text2doc", Text2Doc(tokenizer=tokenizer)),
+                               ("hashvec", CharHashVectorizer(ngram_range=ngram_range,
+                                                              alternate_sign=alternate_sign))])
+
+    df = pd.DataFrame().from_records(load_tweet_sentiment_train()).sample(50, random_state=42)
+
+    assert df.shape[0] == feng_pipeline.fit_transform(df.tweet).shape[0]


### PR DESCRIPTION
- Receive `ngram_range`.
- Calculate n_grams within a `Doc` object's lowerized tokens.
- Send (`n_gram`, str) pair iterator to FeatureHasher.
- Implement tests with tokenizer and ngram_range configurations. 