### PR TITLE
Test Cases for Tokenizer Handlers [resolves #273]

### DIFF
--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -38,7 +38,7 @@ class OnlinePipeline(Pipeline):
 
 
 class Text2Doc(BaseEstimator, TransformerMixin):
-    Doc = None
+    #Doc = None
 
     def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, progress_tracking=True):
         self.tokenizer = tokenizer
@@ -51,11 +51,10 @@ class Text2Doc(BaseEstimator, TransformerMixin):
         self.init()
 
     def init(self):
-        if Text2Doc.Doc is None:
-            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji'):
+        if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji'):
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
                                           tokenizer__mention=self.mention, tokenizer__emoji=self.emoji)
-            else:
+        else:
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
                                           tokenizer__mention=False, tokenizer__emoji=False)
 
@@ -81,7 +80,7 @@ class Text2Doc(BaseEstimator, TransformerMixin):
         docs = []
 
         for text in tqdm(X, disable=not hasattr(self, 'progress_tracking') or not self.progress_tracking, unit="doc"):
-            docs.append(Text2Doc.Doc(text))
+            docs.append(self.Doc(text))
 
         return docs
 

--- a/sadedegel/prebuilt/customer_reviews_classification.py
+++ b/sadedegel/prebuilt/customer_reviews_classification.py
@@ -53,7 +53,6 @@ def build(max_rows=-1, save=True):
 
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        pipeline.steps[0][1].Doc = None
 
         dump(pipeline, (model_dir / 'customer_review_classification.joblib').absolute(), compress=('gzip', 9))
 

--- a/sadedegel/prebuilt/model/customer_review_classification.joblib
+++ b/sadedegel/prebuilt/model/customer_review_classification.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7eaa49b33373fa41e2512892747a3a778bca561d8f75afcb003a498b29876a36
-size 12102106
+oid sha256:0a3edf2a5f6deccf2aaa7bd9eec79850ba3bd596933c69713c17ff68f2565df7
+size 12102133

--- a/sadedegel/prebuilt/model/movie_sentiment.joblib
+++ b/sadedegel/prebuilt/model/movie_sentiment.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb3348d6f1e1725ccd75eda7446c62efc882cf0cab54d02530e92440ca4d87b7
-size 335083
+oid sha256:a63379a73f7a6f6e0b26d3ad8f5ca77b3e09cd02173b07790208f7f3f9d1e9e5
+size 335117

--- a/sadedegel/prebuilt/model/news_classification.joblib
+++ b/sadedegel/prebuilt/model/news_classification.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3d16653d69585f5b943a3ed60ee0d7a54d4f9e9b8102f4e39d78c7e6b2881f2
-size 5954357
+oid sha256:43ce8361dc32bcf86415b5d8a8a45f5647b3a65b2781fadef9355fbfbf8b2d76
+size 5954186

--- a/sadedegel/prebuilt/model/telco_sentiment_classification.joblib
+++ b/sadedegel/prebuilt/model/telco_sentiment_classification.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5eee18cb9f05c35f813c18c976ab5dbff4037820a98edc17aa8ac4fb95ad10ad
-size 142543
+oid sha256:7b6b7f34cf863d59430cdc9e0c72d331f64c729cab86f003a415dd569ceb1033
+size 191076

--- a/sadedegel/prebuilt/model/tweet_profanity_classification.joblib
+++ b/sadedegel/prebuilt/model/tweet_profanity_classification.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6652da27d6e34e588a52b1bb02c73bdcadbf4328bf169cae92f3dfecea17d310
-size 1056980
+oid sha256:897f4a2610d1ace29421f03dd580c523b0a03010f8257433827ff65de1bc2164
+size 1516739

--- a/sadedegel/prebuilt/model/tweet_sentiment.joblib
+++ b/sadedegel/prebuilt/model/tweet_sentiment.joblib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53757d311f78d5d43a536bc50b391c3231f0bc44d0247e68e23c5634cc22d688
-size 195023
+oid sha256:2a6f3211748c628bc6f3c7e315327e4eff35f9aa93dffd52945c1c624cc32c60
+size 279611

--- a/sadedegel/prebuilt/movie_reviews.py
+++ b/sadedegel/prebuilt/movie_reviews.py
@@ -54,7 +54,6 @@ def build(max_rows=-1, save=True):
 
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        pipeline.steps[0][1].Doc = None
 
         dump(pipeline, (model_dir / 'movie_sentiment.joblib').absolute(), compress=('gzip', 9))
 

--- a/sadedegel/prebuilt/news_classification.py
+++ b/sadedegel/prebuilt/news_classification.py
@@ -70,7 +70,6 @@ def build(max_rows=-1, batch_size=10000):
 
     model_dir.mkdir(parents=True, exist_ok=True)
 
-    pipeline.steps[0][1].Doc = None
 
     dump(pipeline, (model_dir / 'news_classification.joblib').absolute(), compress=('gzip', 9))
 

--- a/sadedegel/prebuilt/telco_sentiment.py
+++ b/sadedegel/prebuilt/telco_sentiment.py
@@ -50,7 +50,6 @@ def build(save=True):
 
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        pipeline.steps[0][1].Doc = None
 
         dump(pipeline, (model_dir / 'telco_sentiment_classification.joblib').absolute(), compress=('gzip', 9))
 

--- a/sadedegel/prebuilt/tweet_profanity.py
+++ b/sadedegel/prebuilt/tweet_profanity.py
@@ -50,7 +50,6 @@ def build(save=True):
 
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        pipeline.steps[0][1].Doc = None
 
         dump(pipeline, (model_dir / 'tweet_profanity_classification.joblib').absolute(), compress=('gzip', 9))
 

--- a/sadedegel/prebuilt/tweet_sentiment.py
+++ b/sadedegel/prebuilt/tweet_sentiment.py
@@ -108,7 +108,6 @@ def build(max_instances=-1, save=True):
 
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        pipeline.steps[0][1].Doc = None
 
         dump(pipeline, (model_dir / 'tweet_sentiment.joblib').absolute(), compress=('gzip', 9))
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,6 +7,7 @@ from sadedegel.dataset import load_raw_corpus, load_sentence_corpus  # noqa # py
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer, LexRankSummarizer  # noqa # pylint: disable=unused-import, wrong-import-position, line-too-long
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer, ICUTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import Text2Doc # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import Token # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_tokenizer_flags.py
+++ b/tests/test_tokenizer_flags.py
@@ -1,7 +1,6 @@
 import pytest
-from sadedegel.extension.sklearn import Text2Doc
 
-from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
+from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer, Text2Doc
 
 
 @pytest.mark.parametrize('toker, text, tokens_true', [

--- a/tests/test_tokenizer_flags.py
+++ b/tests/test_tokenizer_flags.py
@@ -1,0 +1,82 @@
+import pkgutil  # noqa: F401 # pylint: disable=unused-import
+
+import numpy as np
+import pytest
+
+from .context import Doc, SimpleTokenizer, BertTokenizer, tokenizer_context, WordTokenizer, ICUTokenizer
+from .context import load_raw_corpus
+
+
+@pytest.mark.skipif('pkgutil.find_loader("transformers") is None')
+def test_bert_tokenizer():
+    bt = BertTokenizer()
+    text = "Havaalanında bekliyoruz."
+    tokens = bt(text)
+    assert tokens == ['Havaalanı', '##nda', 'bekliyoruz', '.']
+
+
+@pytest.mark.parametrize("text, tokens_true", [("Havaalanında bekliyoruz.", ['Havaalanında', 'bekliyoruz', '.']),
+                                               ('Ali topu tut.', ['Ali', 'topu', 'tut', '.'])])
+def test_simple_tokenizer(text, tokens_true):
+    st = SimpleTokenizer()
+    tokens_pred = st(text)
+    assert tokens_pred == tokens_true
+
+
+def test_simple_tokenization_sentences():
+    text = 'Merhaba dünya. Barış için geldik.'
+
+    with tokenizer_context(SimpleTokenizer.__name__):
+        doc = Doc(text)
+
+        assert doc[0].tokens == ['Merhaba', 'dünya', '.']
+        assert doc[1].tokens == ['Barış', 'için', 'geldik', '.']
+
+
+@pytest.mark.skipif('pkgutil.find_loader("transformers") is None')
+def test_bert_tokenization_sents():
+    text = 'Merhaba dünya. Barış için geldik.'
+
+    with tokenizer_context(BertTokenizer.__name__):
+        doc = Doc(text)
+
+        assert doc[0].tokens == ['Merhaba', 'dünya', '.']
+        assert doc[1].tokens == ['Barış', 'için', 'geldik', '.']
+
+
+def test_tokenizer_type():
+    st1 = WordTokenizer.factory('simple')
+    st2 = WordTokenizer.factory('simple-tokenizer')
+    st3 = WordTokenizer.factory('SimpleTokenizer')
+
+    assert isinstance(st1, SimpleTokenizer) == isinstance(st2, SimpleTokenizer) == isinstance(st3, SimpleTokenizer)
+
+    if pkgutil.find_loader("transformers") is not None:
+        bt1 = WordTokenizer.factory('bert')
+        bt2 = WordTokenizer.factory('bert-tokenizer')
+        bt3 = WordTokenizer.factory('BERTTokenizer')
+
+        assert isinstance(bt1, BertTokenizer) and isinstance(bt2, BertTokenizer) and isinstance(bt3, BertTokenizer)
+
+    icut1 = WordTokenizer.factory('icu')
+    icut2 = WordTokenizer.factory('icu-tokenizer')
+    icut3 = WordTokenizer.factory('ICUTokenizer')
+
+    assert isinstance(icut1, ICUTokenizer) == isinstance(icut2, ICUTokenizer) == isinstance(icut3, ICUTokenizer)
+
+
+@pytest.mark.parametrize("toker", ["bert", "simple", "icu"])
+def test_word_counting(toker):
+    if pkgutil.find_loader("transformers") is not None or toker != "bert":
+        with tokenizer_context(toker) as D:
+            docs = [D(text) for text in load_raw_corpus()]
+
+            if toker == "bert":
+                assert np.array([len(d) for d in docs]).mean() == pytest.approx(42.3775510)
+                assert np.array([len(s) for d in docs for s in d]).mean() == pytest.approx(17.9340236)
+            elif toker == 'simple':
+                assert np.array([len(d) for d in docs]).mean() == pytest.approx(42.3775510)
+                assert np.array([len(s) for d in docs for s in d]).mean() == pytest.approx(12.4676138)
+            else:
+                assert np.array([len(d) for d in docs]).mean() == pytest.approx(42.3775510)
+                assert np.array([len(s) for d in docs for s in d]).mean() == pytest.approx(13.5215507)

--- a/tests/test_tokenizer_flags.py
+++ b/tests/test_tokenizer_flags.py
@@ -11,7 +11,7 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
 ])
 def test_tokenizer_emoji(text, tokens_true, toker):
     it = toker(emoji=True)
-    tokens_pred = it._tokenize(text)
+    tokens_pred = it(text)
     assert tokens_pred == tokens_true
 
 
@@ -22,7 +22,7 @@ def test_tokenizer_emoji(text, tokens_true, toker):
 ])
 def test_tokenizer_mention(text, tokens_true, toker):
     it = toker(mention=True)
-    tokens_pred = it._tokenize(text)
+    tokens_pred = it(text)
     assert tokens_pred == tokens_true
 
 
@@ -34,5 +34,5 @@ def test_tokenizer_mention(text, tokens_true, toker):
 
 def test_tokenizer_hashtag(text, tokens_true, toker):
     it = toker(hashtag=True)
-    tokens_pred = it._tokenize(text)
+    tokens_pred = it(text)
     assert tokens_pred == tokens_true

--- a/tests/test_tokenizer_flags.py
+++ b/tests/test_tokenizer_flags.py
@@ -10,8 +10,8 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
      ['👍', 'basar', '##ili', 've', 'kaliteli', 'bir', 'ur', '##un', '.'])
 ])
 def test_tokenizer_emoji(text, tokens_true, toker):
-    it = toker(emoji=True)
-    tokens_pred = it(text)
+    tokenizer = toker(emoji=True)
+    tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true
 
 
@@ -21,18 +21,17 @@ def test_tokenizer_emoji(text, tokens_true, toker):
     (BertTokenizer, 'çok güzel kütüphane olmuş @sadedegel', ['çok', 'güzel', 'kütüphane', 'olmuş', '@sadedegel'])
 ])
 def test_tokenizer_mention(text, tokens_true, toker):
-    it = toker(mention=True)
-    tokens_pred = it(text)
+    tokenizer = toker(mention=True)
+    tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true
 
 
 @pytest.mark.parametrize('toker, text, tokens_true', [
     (ICUTokenizer, 'ağaçlar yanmasın! #yeşiltürkiye', ['ağaçlar', 'yanmasın', '!', '#yeşiltürkiye']),
-    (SimpleTokenizer, 'ağaçlar yanmasın! #yeşiltürkiye', ['ağaçlar', 'yanmasın', 'yeşiltürkiye']),
+    (SimpleTokenizer, 'ağaçlar yanmasın! #yeşiltürkiye', ['ağaçlar', 'yanmasın', '#yeşiltürkiye']),
     (BertTokenizer, 'ağaçlar yanmasın! #yeşiltürkiye', ['ağaçlar', 'yanma', '##sın', '!', '#yeşiltürkiye'])
 ])
-
 def test_tokenizer_hashtag(text, tokens_true, toker):
-    it = toker(hashtag=True)
-    tokens_pred = it(text)
+    tokenizer = toker(hashtag=True)
+    tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true

--- a/tests/test_tokenizer_flags.py
+++ b/tests/test_tokenizer_flags.py
@@ -1,4 +1,5 @@
 import pytest
+from sadedegel.extension.sklearn import Text2Doc
 
 from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
 
@@ -35,3 +36,39 @@ def test_tokenizer_hashtag(text, tokens_true, toker):
     tokenizer = toker(hashtag=True)
     tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true
+
+
+# Text2Doc Tests
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    ('icu', ['👍basarili ve kaliteli bir urun .'], ['👍', 'basarili', 've', 'kaliteli', 'bir', 'urun', '.']),
+    ('simple', ['👍basarili ve kaliteli bir urun .'], ['👍', 'basarili', 've', 'kaliteli', 'bir', 'urun', '.']),
+    ('bert', ['👍basarili ve kaliteli bir urun .'],
+     ['👍', 'basar', '##ili', 've', 'kaliteli', 'bir', 'ur', '##un', '.'])
+])
+def test_t2d_emoji(text, tokens_true, toker):
+    tokenizer = Text2Doc(tokenizer=toker, emoji=True)
+    tokens_pred = tokenizer.transform(text)
+    assert tokens_pred[0].tokens == tokens_true
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    ('icu', ['çok güzel kütüphane olmuş @sadedegel'], ['çok', 'güzel', 'kütüphane', 'olmuş', '@sadedegel']),
+    ('simple', ['çok güzel kütüphane olmuş @sadedegel'], ['çok', 'güzel', 'kütüphane', 'olmuş', '@sadedegel']),
+    ('bert', ['çok güzel kütüphane olmuş @sadedegel'], ['çok', 'güzel', 'kütüphane', 'olmuş', '@sadedegel'])
+])
+def test_t2d_mention(text, tokens_true, toker):
+    tokenizer = Text2Doc(tokenizer=toker, mention=True)
+    tokens_pred = tokenizer.transform(text)
+    assert tokens_pred[0].tokens == tokens_true
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    ('icu', ['ağaçlar yanmasın! #yeşiltürkiye'], ['ağaçlar', 'yanmasın', '!', '#yeşiltürkiye']),
+    ('simple', ['ağaçlar yanmasın! #yeşiltürkiye'], ['ağaçlar', 'yanmasın', '#yeşiltürkiye']),
+    ('bert', ['ağaçlar yanmasın! #yeşiltürkiye'], ['ağaçlar', 'yanma', '##sın', '!', '#yeşiltürkiye'])
+])
+def test_t2d_hashtag(text, tokens_true, toker):
+    tokenizer = Text2Doc(tokenizer=toker, hashtag=True)
+    tokens_pred = tokenizer.transform(text)
+    assert tokens_pred[0].tokens == tokens_true


### PR DESCRIPTION
### Files changed:
`tests/test_tokenizer_flags.py:`

- Added 'mention' flag to check handlers for three tokenizers (ICU, Simple, BERT)
- Added 'emoji' flag to check handlers for three tokenizers (ICU, Simple, BERT)
- Added 'hashtag' flag to check handlers for three tokenizers (ICU, Simple, BERT)

### To-do:

Going to add test cases for Text2Doc with @onatyap and enrich test cases for different options.