### PR TITLE
Implement Character Repetition Correction [resolves #268]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -604,7 +604,8 @@ class DocBuilder:
 
         self.tokenizer = WordTokenizer.factory(tokenizer_str, emoji=self.config['tokenizer'].getboolean('emoji'),
                                                hashtag=self.config['tokenizer'].getboolean('hashtag'),
-                                               mention=self.config['tokenizer'].getboolean('mention'))
+                                               mention=self.config['tokenizer'].getboolean('mention'),
+                                               repetition=self.config['tokenizer'].getboolean(('repetition')))
 
         Token.set_vocabulary(self.tokenizer.vocabulary)
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -605,7 +605,7 @@ class DocBuilder:
         self.tokenizer = WordTokenizer.factory(tokenizer_str, emoji=self.config['tokenizer'].getboolean('emoji'),
                                                hashtag=self.config['tokenizer'].getboolean('hashtag'),
                                                mention=self.config['tokenizer'].getboolean('mention'),
-                                               repetition=self.config['tokenizer'].getboolean(('repetition')))
+                                               repetition=self.config['tokenizer'].getboolean('repetition'))
 
         Token.set_vocabulary(self.tokenizer.vocabulary)
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -605,7 +605,7 @@ class DocBuilder:
         self.tokenizer = WordTokenizer.factory(tokenizer_str, emoji=self.config['tokenizer'].getboolean('emoji'),
                                                hashtag=self.config['tokenizer'].getboolean('hashtag'),
                                                mention=self.config['tokenizer'].getboolean('mention'),
-                                               repetition=self.config['tokenizer'].getboolean('repetition'))
+                                               correct_repeats=self.config['tokenizer'].getboolean('correct_repeats'))
 
         Token.set_vocabulary(self.tokenizer.vocabulary)
 

--- a/sadedegel/bblock/util.py
+++ b/sadedegel/bblock/util.py
@@ -7,6 +7,7 @@ from typing import List
 
 import numpy as np
 from rich.console import Console
+import re
 
 from ..about import __version__
 
@@ -28,6 +29,10 @@ def tr_lower(s: str) -> str:
 
 def tr_upper(s: str) -> str:
     return s.replace("i", "İ").upper()
+
+def repetition_correct(s):
+    pattern = re.compile(r"(.)\1{2,}", re.DOTALL)
+    return pattern.sub(r"\1", s)
 
 
 def space_pad(token):

--- a/sadedegel/bblock/word_tokenizer.py
+++ b/sadedegel/bblock/word_tokenizer.py
@@ -38,7 +38,7 @@ console = Console()
 class WordTokenizer(ABC):
     __instances = {}
 
-    def __init__(self, mention=False, hashtag=False, emoji=False):
+    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
         """
 
         @param mention: Handle mention in tweet texts.
@@ -49,6 +49,7 @@ class WordTokenizer(ABC):
         self.mention = mention
         self.hashtag = hashtag
         self.emoji = emoji
+        self.repetition = repetition
 
         self.regexes = []
 
@@ -130,20 +131,20 @@ class WordTokenizer(ABC):
             return tokens
 
     @staticmethod
-    def factory(tokenizer_name: str, mention=False, hashtag=False, emoji=False):
-        console.log(f"mention={mention}, hashtag={hashtag}, emoji={emoji}")
+    def factory(tokenizer_name: str, mention=False, hashtag=False, emoji=False, repetition=False):
+        console.log(f"mention={mention}, hashtag={hashtag}, emoji={emoji}, repetition={repetition}")
         normalized_name = normalize_tokenizer_name(tokenizer_name)
         if normalized_name not in WordTokenizer.__instances:
             if normalized_name == "bert":
-                return BertTokenizer(mention, hashtag, emoji)
+                return BertTokenizer(mention, hashtag, emoji, repetition)
             elif normalized_name == "simple":
                 warnings.warn(
                     ("Note that SimpleTokenizer is pretty new in sadedeGel. "
                      "If you experience any problems, open up a issue "
                      "(https://github.com/GlobalMaksimum/sadedegel/issues/new)"))
-                return SimpleTokenizer(mention, hashtag, emoji)
+                return SimpleTokenizer(mention, hashtag, emoji, repetition)
             elif normalized_name == "icu":
-                return ICUTokenizer(mention, hashtag, emoji)
+                return ICUTokenizer(mention, hashtag, emoji, repetition)
             else:
                 raise Exception(
                     (f"No word tokenizer type match with name {tokenizer_name}."
@@ -158,8 +159,8 @@ class BertTokenizer(WordTokenizer):
     def convert_tokens_to_ids(self, tokens: List[Token]) -> List[int]:
         return self.tokenizer.convert_tokens_to_ids([t.word for t in tokens])
 
-    def __init__(self, mention=False, hashtag=False, emoji=False):
-        super(BertTokenizer, self).__init__(mention, hashtag, emoji)
+    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
+        super(BertTokenizer, self).__init__(mention, hashtag, emoji, repetition)
 
         self.tokenizer = None
 
@@ -190,8 +191,8 @@ class BertTokenizer(WordTokenizer):
 class SimpleTokenizer(WordTokenizer):
     __name__ = "SimpleTokenizer"
 
-    def __init__(self, mention=False, hashtag=False, emoji=False):
-        super(SimpleTokenizer, self).__init__(mention, hashtag, emoji)
+    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
+        super(SimpleTokenizer, self).__init__(mention, hashtag, emoji, repetition)
         self.tokenizer = word_tokenize
 
     def _tokenize(self, text: str) -> List[str]:
@@ -213,8 +214,8 @@ class SimpleTokenizer(WordTokenizer):
 class ICUTokenizer(WordTokenizer):
     __name__ = "ICUTokenizer"
 
-    def __init__(self, mention=False, hashtag=False, emoji=False):
-        super(ICUTokenizer, self).__init__(mention, hashtag, emoji)
+    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
+        super(ICUTokenizer, self).__init__(mention, hashtag, emoji, repetition)
         self.tokenizer = ICUTokenizerHelper()
 
     def _tokenize(self, text: str) -> List[str]:

--- a/sadedegel/bblock/word_tokenizer.py
+++ b/sadedegel/bblock/word_tokenizer.py
@@ -11,7 +11,7 @@ from cached_property import cached_property
 from rich.console import Console
 
 from sadedegel.bblock.word_tokenizer_helper import ICUTokenizerHelper
-from .util import normalize_tokenizer_name
+from .util import normalize_tokenizer_name, repetition_correct
 from .vocabulary import Vocabulary
 from .token import Token
 from .word_tokenizer_helper import word_tokenize
@@ -53,6 +53,7 @@ class WordTokenizer(ABC):
 
         self.regexes = []
 
+
         if self.hashtag:
             console.print("Handling hashtags")
             self.regexes.append(re.compile(r"(?P<hashtag>#\S+)"))
@@ -80,6 +81,9 @@ class WordTokenizer(ABC):
 
     def __call__(self, sentence: str) -> List[Token]:
         text = str(sentence)
+
+        if self.repetition:
+            text = repetition_correct(text)
 
         if len(self.regexes) == 0:
             return [Token(t) for t in self._tokenize(text)]

--- a/sadedegel/bblock/word_tokenizer.py
+++ b/sadedegel/bblock/word_tokenizer.py
@@ -38,7 +38,7 @@ console = Console()
 class WordTokenizer(ABC):
     __instances = {}
 
-    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
+    def __init__(self, mention=False, hashtag=False, emoji=False, correct_repeats=False):
         """
 
         @param mention: Handle mention in tweet texts.
@@ -49,7 +49,7 @@ class WordTokenizer(ABC):
         self.mention = mention
         self.hashtag = hashtag
         self.emoji = emoji
-        self.repetition = repetition
+        self.correct_repeats = correct_repeats
 
         self.regexes = []
 
@@ -82,7 +82,7 @@ class WordTokenizer(ABC):
     def __call__(self, sentence: str) -> List[Token]:
         text = str(sentence)
 
-        if self.repetition:
+        if self.correct_repeats:
             text = repetition_correct(text)
 
         if len(self.regexes) == 0:
@@ -135,20 +135,20 @@ class WordTokenizer(ABC):
             return tokens
 
     @staticmethod
-    def factory(tokenizer_name: str, mention=False, hashtag=False, emoji=False, repetition=False):
-        console.log(f"mention={mention}, hashtag={hashtag}, emoji={emoji}, repetition={repetition}")
+    def factory(tokenizer_name: str, mention=False, hashtag=False, emoji=False, correct_repeats=False):
+        console.log(f"mention={mention}, hashtag={hashtag}, emoji={emoji}, correct_repeats={correct_repeats}")
         normalized_name = normalize_tokenizer_name(tokenizer_name)
         if normalized_name not in WordTokenizer.__instances:
             if normalized_name == "bert":
-                return BertTokenizer(mention, hashtag, emoji, repetition)
+                return BertTokenizer(mention, hashtag, emoji, correct_repeats)
             elif normalized_name == "simple":
                 warnings.warn(
                     ("Note that SimpleTokenizer is pretty new in sadedeGel. "
                      "If you experience any problems, open up a issue "
                      "(https://github.com/GlobalMaksimum/sadedegel/issues/new)"))
-                return SimpleTokenizer(mention, hashtag, emoji, repetition)
+                return SimpleTokenizer(mention, hashtag, emoji, correct_repeats)
             elif normalized_name == "icu":
-                return ICUTokenizer(mention, hashtag, emoji, repetition)
+                return ICUTokenizer(mention, hashtag, emoji, correct_repeats)
             else:
                 raise Exception(
                     (f"No word tokenizer type match with name {tokenizer_name}."
@@ -163,8 +163,8 @@ class BertTokenizer(WordTokenizer):
     def convert_tokens_to_ids(self, tokens: List[Token]) -> List[int]:
         return self.tokenizer.convert_tokens_to_ids([t.word for t in tokens])
 
-    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
-        super(BertTokenizer, self).__init__(mention, hashtag, emoji, repetition)
+    def __init__(self, mention=False, hashtag=False, emoji=False, correct_repeats=False):
+        super(BertTokenizer, self).__init__(mention, hashtag, emoji, correct_repeats)
 
         self.tokenizer = None
 
@@ -195,8 +195,8 @@ class BertTokenizer(WordTokenizer):
 class SimpleTokenizer(WordTokenizer):
     __name__ = "SimpleTokenizer"
 
-    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
-        super(SimpleTokenizer, self).__init__(mention, hashtag, emoji, repetition)
+    def __init__(self, mention=False, hashtag=False, emoji=False, correct_repeats=False):
+        super(SimpleTokenizer, self).__init__(mention, hashtag, emoji, correct_repeats)
         self.tokenizer = word_tokenize
 
     def _tokenize(self, text: str) -> List[str]:
@@ -218,8 +218,8 @@ class SimpleTokenizer(WordTokenizer):
 class ICUTokenizer(WordTokenizer):
     __name__ = "ICUTokenizer"
 
-    def __init__(self, mention=False, hashtag=False, emoji=False, repetition=False):
-        super(ICUTokenizer, self).__init__(mention, hashtag, emoji, repetition)
+    def __init__(self, mention=False, hashtag=False, emoji=False, correct_repeats=False):
+        super(ICUTokenizer, self).__init__(mention, hashtag, emoji, correct_repeats)
         self.tokenizer = ICUTokenizerHelper()
 
     def _tokenize(self, text: str) -> List[str]:

--- a/sadedegel/default.ini
+++ b/sadedegel/default.ini
@@ -8,7 +8,7 @@ drop_punct = false
 hashtag = false
 mention = false
 emoji = false
-repetition = false
+correct_repeats = false
 
 [bert]
 avg_document_length = 42.37

--- a/sadedegel/default.ini
+++ b/sadedegel/default.ini
@@ -8,6 +8,7 @@ drop_punct = false
 hashtag = false
 mention = false
 emoji = false
+repetition = false
 
 [bert]
 avg_document_length = 42.37

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -40,11 +40,12 @@ class OnlinePipeline(Pipeline):
 class Text2Doc(BaseEstimator, TransformerMixin):
     Doc = None
 
-    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, progress_tracking=True):
+    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, repetition=False, progress_tracking=True):
         self.tokenizer = tokenizer
         self.hashtag = hashtag
         self.mention = mention
         self.emoji = emoji
+        self.repetition = repetition
         self.progress_tracking = progress_tracking
         # TODO: Add sadedegel version
 
@@ -52,12 +53,13 @@ class Text2Doc(BaseEstimator, TransformerMixin):
 
     def init(self):
         if Text2Doc.Doc is None:
-            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji'):
+            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(self, 'repetition'):
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
-                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji)
+                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
+                                          tokenizer__repetition=self.repetition)
             else:
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
-                                          tokenizer__mention=False, tokenizer__emoji=False)
+                                          tokenizer__mention=False, tokenizer__emoji=False, tokenizer__repetition=False)
 
     def fit(self, X, y=None):
         return self

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -40,12 +40,12 @@ class OnlinePipeline(Pipeline):
 class Text2Doc(BaseEstimator, TransformerMixin):
     Doc = None
 
-    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, repetition=False, progress_tracking=True):
+    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, correct_repeats=False, progress_tracking=True):
         self.tokenizer = tokenizer
         self.hashtag = hashtag
         self.mention = mention
         self.emoji = emoji
-        self.repetition = repetition
+        self.correct_repeats = correct_repeats
         self.progress_tracking = progress_tracking
         # TODO: Add sadedegel version
 
@@ -53,13 +53,13 @@ class Text2Doc(BaseEstimator, TransformerMixin):
 
     def init(self):
         if Text2Doc.Doc is None:
-            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(self, 'repetition'):
+            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(self, 'correct_repeats'):
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
                                           tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
-                                          tokenizer__repetition=self.repetition)
+                                          tokenizer__correct_repeats=self.correct_repeats)
             else:
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
-                                          tokenizer__mention=False, tokenizer__emoji=False, tokenizer__repetition=False)
+                                          tokenizer__mention=False, tokenizer__emoji=False, tokenizer__correct_repeats=False)
 
     def fit(self, X, y=None):
         return self

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,6 +7,7 @@ from sadedegel.dataset import load_raw_corpus, load_sentence_corpus  # noqa # py
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer, LexRankSummarizer  # noqa # pylint: disable=unused-import, wrong-import-position, line-too-long
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer, ICUTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import Text2Doc # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import Token # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_repetition.py
+++ b/tests/test_repetition.py
@@ -8,7 +8,7 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer, Text2Doc
     (SimpleTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alemin', 'kralı', 'geliyor', 'geliyor']),
     (BertTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
 ])
-def test_tokenizer_emoji(text, tokens_true, toker):
+def test_tokenizer_repeat(text, tokens_true, toker):
     tokenizer = toker(repetition=True)
     tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true
@@ -19,9 +19,7 @@ def test_tokenizer_emoji(text, tokens_true, toker):
     ('simple', ['alemiiiin kralı geliyooor geliyooooooor'], ['alemin', 'kralı', 'geliyor', 'geliyor']),
     ('bert', ['alemiiiin kralı geliyooor geliyooooooor'], ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
 ])
-
-
-def test_t2d_hashtag(text, tokens_true, toker):
+def test_t2d_repeat(text, tokens_true, toker):
     tokenizer = Text2Doc(tokenizer=toker, repetition=True)
     tokens_pred = tokenizer.transform(text)
     assert tokens_pred[0].tokens == tokens_true

--- a/tests/test_repetition.py
+++ b/tests/test_repetition.py
@@ -1,0 +1,27 @@
+import pytest
+
+from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer, Text2Doc
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    (ICUTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alemin', 'kralı', 'geliyor', 'geliyor']),
+    (SimpleTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alemin', 'kralı', 'geliyor', 'geliyor']),
+    (BertTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
+])
+def test_tokenizer_emoji(text, tokens_true, toker):
+    tokenizer = toker(repetition=True)
+    tokens_pred = tokenizer(text)
+    assert tokens_pred == tokens_true
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    ('icu', ['alemiiiin kralı geliyooor geliyooooooor'], ['alemin', 'kralı', 'geliyor', 'geliyor']),
+    ('simple', ['alemiiiin kralı geliyooor geliyooooooor'], ['alemin', 'kralı', 'geliyor', 'geliyor']),
+    ('bert', ['alemiiiin kralı geliyooor geliyooooooor'], ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
+])
+
+
+def test_t2d_hashtag(text, tokens_true, toker):
+    tokenizer = Text2Doc(tokenizer=toker, repetition=True)
+    tokens_pred = tokenizer.transform(text)
+    assert tokens_pred[0].tokens == tokens_true

--- a/tests/test_repetition.py
+++ b/tests/test_repetition.py
@@ -9,7 +9,7 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer, Text2Doc
     (BertTokenizer, 'alemiiiin kralı geliyooor geliyooooooor', ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
 ])
 def test_tokenizer_repeat(text, tokens_true, toker):
-    tokenizer = toker(repetition=True)
+    tokenizer = toker(correct_repeats=True)
     tokens_pred = tokenizer(text)
     assert tokens_pred == tokens_true
 
@@ -20,6 +20,6 @@ def test_tokenizer_repeat(text, tokens_true, toker):
     ('bert', ['alemiiiin kralı geliyooor geliyooooooor'], ['alem', '##in', 'kralı', 'geliyor', 'geliyor'])
 ])
 def test_t2d_repeat(text, tokens_true, toker):
-    tokenizer = Text2Doc(tokenizer=toker, repetition=True)
+    tokenizer = Text2Doc(tokenizer=toker, correct_repeats=True)
     tokens_pred = tokenizer.transform(text)
     assert tokens_pred[0].tokens == tokens_true


### PR DESCRIPTION
- Added optional mention, hashtag, emoji like character repetition normalizer for tokenizers and text2doc.
- Normalizer works like how @onatyap proposed in issue #268 
- It takes strings like `"Süppeeeer", "Berbaaat", "Muhteşeemmmm"` and returns `"Süper", "Berbat", "Muhteşem"` in tokenization part.
- Added test cases.
- I tested it on several prebuilt models and here are the results:

<!--StartFragment-->
Prebuilt   Model | Original Result | Preprocessed Result
-- | -- | --
Tweet Sentiment Classification | 3-Fold F-1: 0.8640,     5-Fold F-1: 0.8669 | 3-Fold F-1: 0.8587     5-Fold F-1: 0.8640
Movie Review Sentiment   Classification | F-1: 0.8258 | F-1: 0.8242
Telco Tweet Sentiment   Classification | F-1: 0.6871,     Accuracy: 0.6925 | F-1: 0.696,     Accuracy: 0.691
Turkish Customer Reviews   Classification | F-1: 0.851 | F-1: 0.852

<!--EndFragment-->

- This method might be useful in some cases where data comes in high number of repeated character words.
- Apart from test results @onatyap could you check the code and confirm that what you proposed in the issue?

