### PR TITLE
Movie Sentiment Public Model Evaluation Fix [resolves #284]

### DIFF
--- a/sadedegel/prebuilt/README.md
+++ b/sadedegel/prebuilt/README.md
@@ -103,6 +103,9 @@ y_pred = model.predict(['süper aksiyon, tavsiye ederim'])
 # You can check original test results on holdout set:
 movie_reviews.evaluate()
 ```
+#### Accuracy
+
+Current prebuilt movie review model has a **macro-F1** score of `0.8258` on holdout test set model never seen before.
 
 ### Telco Brand Tweet Sentiment Classification
 


### PR DESCRIPTION
Re-added missing line in `public` models `readme` file mentioned in #284. Evaluated the model using built-in evaluator again to double check the results. Second evaluation confirms that macro f-1 score of `0.8258` is reproducible...