### PR TITLE
Feature/emoticon handler [resolves #264]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -461,7 +461,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         return self.config['default'].getfloat('avg_document_length')
 
     @cached_property
-    def tokens(self) -> List[Token]:
+    def tokens(self) -> List[str]:
         tokens = []
         for s in self:
             for t in s.tokens:
@@ -604,7 +604,8 @@ class DocBuilder:
 
         self.tokenizer = WordTokenizer.factory(tokenizer_str, emoji=self.config['tokenizer'].getboolean('emoji'),
                                                hashtag=self.config['tokenizer'].getboolean('hashtag'),
-                                               mention=self.config['tokenizer'].getboolean('mention'))
+                                               mention=self.config['tokenizer'].getboolean('mention'),
+                                               emoticon=self.config['tokenizer'].getboolean('emoticon'))
 
         Token.set_vocabulary(self.tokenizer.vocabulary)
 

--- a/sadedegel/bblock/token.py
+++ b/sadedegel/bblock/token.py
@@ -104,6 +104,7 @@ class Token:
         token.is_emoji = False
         token.is_hashtag = False
         token.is_mention = False
+        token.is_emoticon = False
 
         return token
 

--- a/sadedegel/bblock/word_tokenizer.py
+++ b/sadedegel/bblock/word_tokenizer.py
@@ -70,7 +70,7 @@ class WordTokenizer(ABC):
             console.print("Handling emoticons")
             self.regexes.append(
                 re.compile(
-                    r"(?P<emoticon>(\:\)+|\:\(+|\;\)+|<3+|\:\/+|\:-\/+|\:\||\:p+|\:P+|\:d+|\:D+|\:-\)+|\:-\(+|xd+|xD+|XD+|\:S+|\:s+|\:\>|\:\'\(+|\:o+|\:c|\:\]|\:-3|\^_\^))"))
+                    r"(?P<emoticon>(\:\)+|\:\(+|\;\)+|<3+|\:\/+|\:-\/+|\:\||\:p+|\:P+|\:d+|\:D+|\:-\)+|\:-\(+|xd+|xD+|XD+|\:S+|\:s+|\:\>|\:\'\(+|\:o+|\:c|\:\]|\:-3|\^_\^))|8=+D"))
 
         if len(self.regexes) > 0:
             self.exception_rules = re.compile('|'.join(x.pattern for x in self.regexes), flags=re.UNICODE)

--- a/sadedegel/default.ini
+++ b/sadedegel/default.ini
@@ -8,6 +8,7 @@ drop_punct = false
 hashtag = false
 mention = false
 emoji = false
+emoticon = false
 
 [bert]
 avg_document_length = 42.37

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -18,7 +18,6 @@ def check_type_all(X, expected_type=str):
 
 def check_type(v, expected_type, error_msg: str) -> None:
     """Check variable type
-
     @param v: Variable to be checked
     @param expected_type: Expected type of variable
     @param error_msg: Error message
@@ -40,11 +39,13 @@ class OnlinePipeline(Pipeline):
 class Text2Doc(BaseEstimator, TransformerMixin):
     Doc = None
 
-    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, progress_tracking=True):
+    def __init__(self, tokenizer="icu", hashtag=False, mention=False, emoji=False, emoticon=False,
+                 progress_tracking=True):
         self.tokenizer = tokenizer
         self.hashtag = hashtag
         self.mention = mention
         self.emoji = emoji
+        self.emoticon = emoticon
         self.progress_tracking = progress_tracking
         # TODO: Add sadedegel version
 
@@ -52,12 +53,15 @@ class Text2Doc(BaseEstimator, TransformerMixin):
 
     def init(self):
         if Text2Doc.Doc is None:
-            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji'):
+            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(
+                    self, 'emoticon'):
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
-                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji)
+                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
+                                          tokenizer__emoticon=self.emoticon)
             else:
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
-                                          tokenizer__mention=False, tokenizer__emoji=False)
+                                          tokenizer__mention=False, tokenizer__emoji=False,
+                                          tokenizer__emoticon=False)
 
     def fit(self, X, y=None):
         return self

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,6 +7,7 @@ from sadedegel.dataset import load_raw_corpus, load_sentence_corpus  # noqa # py
 from sadedegel.summarize import RandomSummarizer, PositionSummarizer, LengthSummarizer, BandSummarizer, Rouge1Summarizer, LexRankSummarizer  # noqa # pylint: disable=unused-import, wrong-import-position, line-too-long
 from sadedegel.tokenize import NLTKPunctTokenizer, RegexpSentenceTokenizer  # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock import Doc, Sentences, BertTokenizer, SimpleTokenizer, WordTokenizer, ICUTokenizer # noqa # pylint: disable=unused-import, wrong-import-position
+from sadedegel.extension.sklearn import Text2Doc # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel import Token # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import tr_upper, tr_lower, __tr_lower__, __tr_upper__ # noqa # pylint: disable=unused-import, wrong-import-position
 from sadedegel.bblock.util import flatten, is_eos  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_emoticon_hdl.py
+++ b/tests/test_emoticon_hdl.py
@@ -1,0 +1,30 @@
+import pytest
+from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    (ICUTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
+     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
+    (SimpleTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
+     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
+    (BertTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
+     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
+])
+def test_tokenizer_emoji(text, tokens_true, toker):
+    tokenizer = toker(emoticon=True)
+    tokens_pred = tokenizer(text)
+    assert tokens_pred == tokens_true
+
+
+@pytest.mark.parametrize('toker, text, tokens_true', [
+    (ICUTokenizer, "komik:)",
+     ["komik", ":", ")"]),
+    (SimpleTokenizer, "komik:)",
+     ["komik"]),
+    (BertTokenizer, "komik:)",
+     ["komik", ":", ")"]),
+])
+def test_tokenizer_emoji_f(text, tokens_true, toker):
+    tokenizer = toker(emoticon=False)
+    tokens_pred = tokenizer(text)
+    assert tokens_pred == tokens_true

--- a/tests/test_emoticon_hdl.py
+++ b/tests/test_emoticon_hdl.py
@@ -3,8 +3,8 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
 
 
 @pytest.mark.parametrize('toker, text, tokens_true', [
-    (ICUTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
-     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
+    (ICUTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^ bu da benimki 8=======D",
+     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^", "bu", "da", "benimki", "8=======D"]),
     (SimpleTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
      ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
     (BertTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",

--- a/tests/test_emoticon_hdl.py
+++ b/tests/test_emoticon_hdl.py
@@ -4,7 +4,8 @@ from .context import SimpleTokenizer, BertTokenizer, ICUTokenizer
 
 @pytest.mark.parametrize('toker, text, tokens_true', [
     (ICUTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^ bu da benimki 8=======D",
-     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^", "bu", "da", "benimki", "8=======D"]),
+     ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^", "bu",
+      "da", "benimki", "8=======D"]),
     (SimpleTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",
      ["komik", ":)", ":(", ";)", "<3", ":/", ":p", ":P", ":d", ":D", ":-)", ":-(", "xd", "xD", ":))))", "^_^"]),
     (BertTokenizer, "komik:) :( ;) <3 :/ :p :P :d :D :-) :-( xd xD :)))) ^_^",


### PR DESCRIPTION
- Added emoticon support for tokenizers. 
- Updated new argument for tokenizers (emoticon=True/False) works much like previous emoji, hashtag, mention handlers.
- Current regex covers most common emoticons you can find on social media and can be updated easily.
- Added and confirmed test cases for emoticon handlers.

**Basic Usage:**

```python
from sadedegel.bblock.tokenizers import ICUTokenizer
text = "komik:))
tokenizer = ICUTokenizer(emoticon=False)
tokenizer(text)
>>output ['komik', ':', ')',')']

### if emoticon set to True:

tokenizer = ICUTokenizer(emoticon=True)
tokenizer(text)
>>output ['komik', ':))']
```