### PR TITLE
Remove sentences access from spans property.

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -495,7 +495,8 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @cached_property
     def spans(self):
-        _ = self._sents
+        _spans = [match.span() for match in re.finditer(r"\S+", self.raw)]
+        self._spans = [Span(i, span, self) for i, span in enumerate(_spans)]
         return self._spans
 
     @cached_property


### PR DESCRIPTION
- Calling spans of a document requires access to sents which loads `sbd`. However training an `sbd` model requires access to spans. This inflicts a circular dependency which is redundant and might cause issues if an `sbd` model is trained from scratch. 