### PR TITLE
Pre-processing options work for PreTrainedVectorizer[resolves #307]

### DIFF
--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -1070,6 +1070,9 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
 
 class DocBuilder:
+    """Builder class for forming a sadedegel Document object.
+    Handles lazy loading of models and initializes config that will be inherited by sadedegel Doc instances.
+    """
     transformer_model = None
     bert_model = None
 
@@ -1099,6 +1102,22 @@ class DocBuilder:
             raise ValueError(f"Unknown term frequency method {idf_method}. Choose on of {IDF_METHOD_VALUES}")
 
     def __call__(self, raw):
+        """Build a sadedegel Doc object via a raw string.
+
+        Parameters
+        ----------
+        raw: str
+            Raw string input to build the document upon.
+
+        Returns
+        -------
+        doc: sadedegel.bblock.Doc
+            A sadedegel Doc object.
+
+        Usage
+        -----
+         `Doc("Merhaba dünya. Biz dostuz. Barış için geldik.")`
+        """
 
         if raw is not None:
             raw_stripped = raw.strip()
@@ -1111,6 +1130,16 @@ class DocBuilder:
         return d
 
     def from_sentences(self, sentences: List[str]):
+        """Build a sadedegel Doc object from a list of raw strings.
+
+        Parameters
+        ----------
+        sentences: List(str)
+
+        Returns
+        -------
+
+        """
         raw = "\n".join(sentences)
 
         d = Document(raw, self)

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -937,7 +937,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
             embeddings = DocBuilder.transformer_model.model.encode([s.text for s in self], show_progress_bar=False,
                                                                    batch_size=4)
         else:
-            embeddings = DocBuilder.transformer_model.model.encode([self.raw], show_progress_bar=False)
+            embeddings = DocBuilder.transformer_model.model.encode([' '.join([token.word for token in self.tokens])], show_progress_bar=False)
 
         return embeddings
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -25,6 +25,10 @@ console = Console()
 
 
 class Span:
+    """Span class to store raw string as the smallest unit within sadedegel object hiearchy.
+    Attributes of this class store rule based user-defined features of a span for training a sentence boundary detection model.
+
+    """
     def __init__(self, i: int, span, doc):
         self.doc = doc
         self.i = i
@@ -38,9 +42,21 @@ class Span:
 
     @property
     def text(self):
+        """Raw string that constitute the Span instance.
+
+        Returns
+        -------
+        raw: str
+        """
         return self.doc.raw[slice(*self.value)]
 
     def span_features(self):
+        """Features of the span.
+
+        Returns
+        -------
+        features: dict
+        """
         is_first_span = self.i == 0
         is_last_span = self.i == len(self.doc._spans) - 1
         word = self.doc.raw[slice(*self.value)]

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -253,6 +253,20 @@ class TFImpl:
 
 
 class BM25Impl:
+    """Base Implementation for BM25 relevance score. Calculate BM25 ant other variants (BM11, BM15) based on user defined configuration parameters.
+
+    For more information on BM25 implementatin refer to: https://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf
+
+    ...
+    Methods
+    -------
+    get_bm25: float
+        Retrieve BM25 relevance score of the sentence w.r.t. its document.
+    get_bm11: float
+        Retrieve BM11 relevance score of the sentence w.r.t. its document.
+    get_bm15: float
+        Retrieve BM15 relevance score of the sentence w.r.t. its document.
+    """
     def __init__(self):
         pass
 
@@ -260,7 +274,34 @@ class BM25Impl:
                  lowercase=False,
                  drop_suffix=False,
                  drop_punct=False, **kwargs):
+        """Retrieve BM25 relevance score of the sentence w.r.t. its document.
 
+        Parameters
+        ----------
+        tf_method: str
+            Term Frequency calculation method.
+        idf_method: str
+            Inverse Document Frequency calculation method.
+        k1: int
+            Smoothing term for weighting in set.
+        b: int
+            Weighting for sentence_len to document_len ratio.
+        delta: float
+            Normalization term for lower bounding de-weighting for very long documents.
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+        **kwargs: dict, optional
+
+        Returns
+        -------
+        bm25: float
+        """
         tf = self.get_tf(tf_method, drop_stopwords, lowercase, drop_suffix, drop_punct, **kwargs)
         idf = self.get_idf(idf_method, drop_stopwords, lowercase, drop_suffix, drop_punct, **kwargs)
 
@@ -271,6 +312,16 @@ class BM25Impl:
     def get_bm11(self, tf_method, idf_method, k1, avgdl, delta=0, drop_stopwords=False, lowercase=False,
                  drop_suffix=False,
                  drop_punct=False, **kwargs):
+        """Retrieve BM11 relevance score of the sentence w.r.t. its document.
+
+        Parameters
+        ----------
+        **kwargs: dict, optional
+
+        Returns
+        -------
+        bm11: float
+        """
         return self.get_bm25(tf_method, idf_method, k1, 1, avgdl, delta, drop_stopwords, lowercase, drop_suffix,
                              drop_punct,
                              kwargs)
@@ -278,6 +329,16 @@ class BM25Impl:
     def get_bm15(self, tf_method, idf_method, k1, avgdl, delta=0, drop_stopwords=False, lowercase=False,
                  drop_suffix=False,
                  drop_punct=False, **kwargs):
+        """Retrieve BM15 relevance score of the sentence w.r.t. its document.
+
+        Parameters
+        ----------
+        **kwargs: dict, optional
+
+        Returns
+        -------
+        bm15: float
+        """
         return self.get_bm25(tf_method, idf_method, k1, 0, avgdl, delta, drop_stopwords, lowercase, drop_suffix,
                              drop_punct,
                              kwargs)

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -1001,7 +1001,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
             console.print("Loading \"dbmdz/bert-base-turkish-cased\"...")
             DocBuilder.bert_model = SentenceTransformer("dbmdz/bert-base-turkish-cased")
 
-        embedding = DocBuilder.bert_model.encode([self.raw], show_progress_bar=False, batch_size=4)
+        embedding = DocBuilder.bert_model.encode([' '.join([token.word for token in self.tokens])], show_progress_bar=False, batch_size=4)
 
         return embedding
 

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -448,8 +448,7 @@ class Sentences(TFImpl, IDFImpl, BM25Impl):
 
 
 class Document(TFImpl, IDFImpl, BM25Impl):
-    """
-    Document class is a sequence of Sentences objects. Access Sentences and Tokens that constitute the Document.
+    """Document class is a sequence of Sentences objects. Access Sentences and Tokens that constitute the Document.
     Generate BoW, W2V or PreTrainedTransformer model based embeddings.
 
     Parameters
@@ -461,7 +460,6 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     Attributes
     ----------
-
     raw: str
         This is where raw document string is stored.
     builder: sadedegel.bblock.DocBuilder
@@ -515,8 +513,8 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @cached_property
     def spans(self) -> List[Span]:
-        """
-        Span objects that constitute the Document
+        """Span objects that constitute the Document
+
         Returns
         -------
         spans: List[sadedegel.bblock.Span]
@@ -526,8 +524,8 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @cached_property
     def tokens(self) -> List[Token]:
-        """
-        Token objects that constitute the Document
+        """Token objects that constitute the Document
+
         Returns
         -------
         tokens: List[sadedegel.bblock.Token]
@@ -536,8 +534,8 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @property
     def vocabulary(self):
-        """
-        Vocabulary that is used as reference for BoW based vector generation.
+        """Vocabulary that is used as reference for BoW based vector generation.
+
         Returns
         -------
         vocabulary: sadedegel.bblock.vocabulary.Vocabulary
@@ -546,8 +544,8 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @property
     def tokenizer(self):
-        """
-        Word tokenizer used to obtain Token objects that constitute the Document object.
+        """Word tokenizer used to obtain Token objects that constitute the Document object.
+
         Returns
         -------
         tokenizer: sadedegel.bblock.WordTokenizer
@@ -574,8 +572,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         return max(len(s.tokens_with_special_symbols) for s in self._sents)
 
     def padded_matrix(self, return_numpy=False, return_mask=True):
-        """
-        A zero-padded numpy.array or torch.tensor formed by sadedegel.tokenizer.BertTokenizer. Can be used for lower-level development of BERT pipelines with torch.
+        """A zero-padded numpy.array or torch.tensor formed by sadedegel.tokenizer.BertTokenizer. Can be used for lower-level development of BERT pipelines with torch.
         One row for each sentence.
         One column for each token (pad 0 if length of sentence is shorter than the max length)
 
@@ -583,12 +580,18 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         -------
         return_numpy: bool
             Whether to return numpy.array or torch.tensor
-        return_mask: BOOL
+        return_mask: bool
             Whether to return padding mask
 
         Returns
         -------
+        padded_matrix: numpy.ndarray or torch.tensor
+            Zero-padded tensor with type_ids of tokens encoded by sadedegel.tokenizer.BertTokenizer. (n_sequences, MAX_LEN)
 
+        Raises
+        ------
+        ImportError
+            If `transformers` module is not present in the environment.
         """
         max_len = self.max_length()
 
@@ -616,8 +619,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
                 return mat
 
     def get_pretrained_embedding(self, architecture: str, do_sents: bool):
-        """
-        Get dense document (or sentence) embeddings from a Transformer based pre-trained model hosted on HuggingFace Hub.
+        """Get dense document (or sentence) embeddings from a Transformer based pre-trained model hosted on HuggingFace Hub.
         The model will be downloaded to a local .cache directory if not locally available and used upon every call.
         GPU availiability is adviced for better speed.
 
@@ -632,6 +634,11 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         -------
         embeddings: numpy.ndarray
             Document (or sentence) embeddings. (1, emb_dim) for document. (n_sents, emb_dim) if do_sents=True.
+
+        Raises
+        ------
+        ImportError
+            If `sentence_transformers` module is not present in the environment.
         """
         try:
             from sentence_transformers import SentenceTransformer
@@ -667,8 +674,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @cached_property
     def bert_embeddings(self):
-        """
-        Get dense sentence embeddings from a BERT base cased model hosted on HuggingFace Hub.
+        """Get dense sentence embeddings from a BERT base cased model hosted on HuggingFace Hub.
         The model will be downloaded to a local .cache directory if not locally available and used upon every call.
         GPU availiability is adviced for better speed.
 
@@ -676,6 +682,11 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         -------
         embeddings: numpy.ndarray
             Sentence embeddings. (n_sents, emb_dim)
+
+        Raises
+        ------
+        ImportError
+            If `sentence_transformers` module is not present in the environment.
         """
         try:
             from sentence_transformers import SentenceTransformer
@@ -695,15 +706,19 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @cached_property
     def bert_document_embedding(self):
-        """
-        Get dense document embedding from a BERT base cased model hosted on HuggingFace Hub.
+        """Get dense document embedding from a BERT base cased model hosted on HuggingFace Hub.
         The model will be downloaded to a local .cache directory if not locally available and used upon every call.
         GPU availiability is adviced for better speed.
 
         Returns
         -------
         embeddings: numpy.ndarray
-        Sentence embeddings. (n_sents, emb_dim)
+            Sentence embeddings. (n_sents, emb_dim)
+
+        Raises
+        ------
+        ImportError
+            If `sentence_transformers` module is not present in the environment.
         """
         try:
             from sentence_transformers import SentenceTransformer
@@ -722,8 +737,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
         return embedding
 
     def get_tfidf(self, tf_method: str, idf_method: str, **kwargs):
-        """
-        Calculates and returns the tf-idf vector for the Document based on provided tf and idf methods.
+        """Calculates and returns the tf-idf vector for the Document based on provided tf and idf methods.
 
         Parameters
         ----------
@@ -741,8 +755,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @property
     def tfidf(self):
-        """
-        Calculates and returns the tf-idf vector for the Document based on configured tf and idf methods.
+        """Calculates and returns the tf-idf vector for the Document based on configured tf and idf methods.
 
         Returns
         -------
@@ -752,8 +765,7 @@ class Document(TFImpl, IDFImpl, BM25Impl):
 
     @property
     def tfidf_matrix(self):
-        """
-        Calculates and returns the tf-idf vector for the Sentences of the Document based on configured tf and idf methods.
+        """Calculates and returns the tf-idf vector for the Sentences of the Document based on configured tf and idf methods.
 
         Returns
         -------

--- a/sadedegel/bblock/doc.py
+++ b/sadedegel/bblock/doc.py
@@ -168,10 +168,41 @@ TF_METHOD_VALUES = [TF_BINARY, TF_RAW, TF_FREQ, TF_LOG_NORM, TF_DOUBLE_NORM]
 
 
 class TFImpl:
+    """Base implementation of Term Frequency. Includes various TF calculation methods for inheritance of sadedegel.bblock.Sentences and sadedegel.bblock.Document.
+
+    ...
+    Methods
+    -------
+    raw_tf: numpy.ndarray
+    binary_tf: numpy.ndarray
+    freq_tf: numpy.ndarray
+    log_norm_tf: numpy.ndarray
+    double_norm_tf: numpy.ndarray
+    get_tf: numpy.ndarray
+    """
     def __init__(self):
         pass
 
     def raw_tf(self, drop_stopwords=False, lowercase=False, drop_suffix=False, drop_punct=False) -> np.ndarray:
+        """Calculate TF with raw token counts.
+
+        Parameters
+        ----------
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+
+        Returns
+        -------
+        tf: numpy.ndarray
+            Sparse TF vector representation
+
+        """
         if lowercase:
             v = np.zeros(self.vocabulary.size)
         else:
@@ -198,9 +229,47 @@ class TFImpl:
         return v
 
     def binary_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False) -> np.ndarray:
+        """Calculate TF with binary occurence. i.e. One-hot representation.
+
+        Parameters
+        ----------
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+
+        Returns
+        -------
+        tf: numpy.ndarray
+            Sparse TF vector representation
+
+        """
         return self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct).clip(max=1)
 
     def freq_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False) -> np.ndarray:
+        """Calculate TF with normalized token counts i.e. frequency.
+
+        Parameters
+        ----------
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+
+        Returns
+        -------
+        tf: numpy.ndarray
+            Sparse TF vector representation
+
+        """
         tf = self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct)
 
         normalization = tf.sum()
@@ -211,10 +280,54 @@ class TFImpl:
             return tf
 
     def log_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False) -> np.ndarray:
+        """Calculate TF with log normalized token counts.
+
+        Parameters
+        ----------
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+
+        Returns
+        -------
+        tf: numpy.ndarray
+            Sparse TF vector representation
+
+        """
         return np.log1p(self.raw_tf(drop_stopwords, lowercase, drop_prefix, drop_punct))
 
     def double_norm_tf(self, drop_stopwords=False, lowercase=False, drop_prefix=False, drop_punct=False,
                        k=0.5) -> np.ndarray:
+        """Calculate TF with normalized token counts i.e. frequency.
+
+        Parameters
+        ----------
+        drop_stopwords: bool
+            Drop stopwords from the sequence.
+        lowercase: bool
+            Lowerize all tokens in sequence.
+        drop_suffix: bool
+            Drop suffixes from sequence that is tokenized by sadedegel.bblock.BertTokenizer.
+        drop_punct: bool
+            Drop punctuation from the sequence.
+        k: float
+            Weighting parameter.
+
+        Returns
+        -------
+        tf: numpy.ndarray
+            Sparse TF vector representation
+
+        Raises
+        ------
+        ValueError
+            If k is not in range (0, 1).
+        """
         if not (0 < k < 1):
             raise ValueError(f"Ensure that 0 < k < 1 for double normalization term frequency calculation ({k} given)")
 
@@ -254,8 +367,7 @@ class TFImpl:
 
 class BM25Impl:
     """Base Implementation for BM25 relevance score. Calculate BM25 ant other variants (BM11, BM15) based on user defined configuration parameters.
-
-    For more information on BM25 implementatin refer to: https://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf
+    For more information on BM25 implementation refer to: https://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf
 
     ...
     Methods

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -120,6 +120,11 @@ class Text2Doc(BaseEstimator, TransformerMixin):
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
                                           tokenizer__mention=False, tokenizer__emoji=False,
                                           tokenizer__emoticon=False)
+        else:
+            if Text2Doc.Doc.tokenizer.hashtag != self.hashtag or Text2Doc.Doc.tokenizer.mention != self.mention or Text2Doc.Doc.tokenizer.emoji != self.emoji or Text2Doc.Doc.tokenizer.emoticon != self.emoticon:
+                Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
+                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
+                                          tokenizer__emoticon=self.emoticon)
 
     def fit(self, X, y=None):
         return self

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -52,7 +52,7 @@ class OnlinePipeline(Pipeline):
         y: array-like, default=None
             array-like of shape (n_samples,).
         kwargs: type
-            Remaining arguments for current estimator.
+            Remaining keyword arguments for current estimator.
 
         Returns
         -------
@@ -84,6 +84,15 @@ class Text2Doc(BaseEstimator, TransformerMixin):
     emoticon: bool, default=False
         Whether to tokenize emoticons by symbols or all together.
     progress_tracking: bool, default=True
+
+    Methods
+    -------
+    fit()
+        Placeholder. Don't use.
+    partial_fit()
+        Placeholder. Don't use.
+    transform()
+        Transforms given list of strings into list of sadedegel's Doc objects which can be tokenized.
     """
 
     Doc = None
@@ -179,6 +188,15 @@ class HashVectorizer(BaseEstimator, TransformerMixin):
     alternate_sign: bool, default=True
         When True, an alternating sign is added to features as to
         approximately converse the linear product in the hashed space.
+
+    Methods
+    -------
+    fit()
+        Placeholder. Don't use.
+    partial_fit()
+        Placeholder. Don't use.
+    transform()
+        Takes sadedegel doc objects and returns matrix of hashed features.
     """
     def __init__(self, n_features: int = 1048576, prefix_range: tuple = (3, 5), *, alternate_sign: bool = True):
         check_type(prefix_range, tuple, f"prefix_range should be of tuple type. {type(prefix_range)} found.")
@@ -239,6 +257,11 @@ class TfidfVectorizer(SadedegelVectorizer):
         Whether to drop or keep punctuations.
     show_progress: bool, default=True
         Whether to keep track of progress or not.
+
+    Methods
+    -------
+    transform()
+        Takes list of sadedegel documents and returns matrix of tf-idf features which is pretrained.
     """
     def __init__(self, *, tf_method='raw', idf_method='probabilistic', drop_stopwords=True,
                  lowercase=True,
@@ -334,6 +357,11 @@ class BM25Vectorizer(SadedegelVectorizer):
         Whether to drop or keep punctuations.
     show_progress: bool, default=True
         Whether to keep track of progress or not.
+
+    Methods
+    -------
+    transform()
+        Takes list of sadedegel documents and returns matrix of features using BM25.
     """
     def __init__(self, *, tf_method='raw', idf_method='probabilistic', k1=1.25, b=0.75, delta=0,
                  drop_stopwords=True,
@@ -352,7 +380,7 @@ class BM25Vectorizer(SadedegelVectorizer):
         self.delta = delta
 
     def transform(self, X, y=None):
-        """Takes list of sadedegel documents and returns matrix of features which is pretrained.
+        """Takes list of sadedegel documents and returns matrix of features using BM25.
 
         Parameters
         ----------
@@ -416,6 +444,12 @@ class PreTrainedVectorizer(BaseEstimator, TransformerMixin):
         Whether to get sentence or raw document embeddings.
     show_progress: bool, default=True
         Whether to keep track of progress or not.
+
+    Methods
+    -------
+    transform()
+        Takes list of sadedegel documents consists of sentences and returns matrix of features which is pretrained.
+
     """
     Doc = None
 
@@ -435,11 +469,11 @@ class PreTrainedVectorizer(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X: array-like
-            List of sadedegel.bblock.doc.Document objects.
+            List of strings.
         Returns
         -------
         csr_matrix: array-like
-            scipy.sparse.csr
+            scipy.sparse.csr of shape (n_samples, n_features)
         """
         if PreTrainedVectorizer.Doc is None:
             PreTrainedVectorizer.Doc = DocBuilder()

--- a/sadedegel/extension/sklearn.py
+++ b/sadedegel/extension/sklearn.py
@@ -110,21 +110,21 @@ class Text2Doc(BaseEstimator, TransformerMixin):
         self.init()
 
     def init(self):
-        if Text2Doc.Doc is None:
-            if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(
-                    self, 'emoticon'):
+        if hasattr(self, 'hashtag') and hasattr(self, 'mention') and hasattr(self, 'emoji') and hasattr(
+                self, 'emoticon'):
+            if Text2Doc.Doc is None:
                 Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
                                           tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
                                           tokenizer__emoticon=self.emoticon)
             else:
-                Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
+                if Text2Doc.Doc.tokenizer.hashtag != self.hashtag or Text2Doc.Doc.tokenizer.mention != self.mention or Text2Doc.Doc.tokenizer.emoji != self.emoji or Text2Doc.Doc.tokenizer.emoticon != self.emoticon:
+                    Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
+                                              tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
+                                              tokenizer__emoticon=self.emoticon)
+        else:
+            Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=False,
                                           tokenizer__mention=False, tokenizer__emoji=False,
                                           tokenizer__emoticon=False)
-        else:
-            if Text2Doc.Doc.tokenizer.hashtag != self.hashtag or Text2Doc.Doc.tokenizer.mention != self.mention or Text2Doc.Doc.tokenizer.emoji != self.emoji or Text2Doc.Doc.tokenizer.emoticon != self.emoticon:
-                Text2Doc.Doc = DocBuilder(tokenizer=self.tokenizer, tokenizer__hashtag=self.hashtag,
-                                          tokenizer__mention=self.mention, tokenizer__emoji=self.emoji,
-                                          tokenizer__emoticon=self.emoticon)
 
     def fit(self, X, y=None):
         return self

--- a/sadedegel/prebuilt/customer_reviews_classification.py
+++ b/sadedegel/prebuilt/customer_reviews_classification.py
@@ -19,6 +19,14 @@ from ..dataset.customer_review import load_train, \
 console = Console()
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc('icu')),
          ('tfidf', TfidfVectorizer(tf_method='log_norm', idf_method='probabilistic', drop_punct=True,
@@ -27,7 +35,26 @@ def empty_model():
          ]
     )
 
+
 def build(max_rows=-1, save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    max_rows: int, default=-1
+        Number of instances to be sampled for training the model.
+    save: bool, default=True
+        Whether to save the model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -62,9 +89,40 @@ def build(max_rows=-1, save=True):
     console.log('Model build [green]DONE[/green]')
 
 def load(model_name='customer_review_classification'):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
-def evaluate(model=None, scoring='f1', max_rows=-1):
+def evaluate(scoring='f1', max_rows=-1):
+    """Evaluates the pretrained model on test set by given metric.
+
+    Parameters
+    ----------
+    scoring: str, default='f1'
+        Scoring metric for evaluation. Can be 'f1' for f-1 macro score or
+        'auc' for roc-auc score.
+    max_rows: int, default=-1
+        Number of test instances to be sampled for evaluating the model.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/food_reviews.py
+++ b/sadedegel/prebuilt/food_reviews.py
@@ -17,6 +17,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc('icu')),
          ('hash', HashVectorizer(n_features=1050000)),
@@ -27,6 +35,24 @@ def empty_model():
 
 
 def build(max_rows=-1, save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    max_rows: int, default=-1
+        Number of instances to be sampled for training the model.
+    save: bool, default=True
+        Whether to save the model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -57,10 +83,42 @@ def build(max_rows=-1, save=True):
 
         dump(pipeline, (model_dir / 'food_sentiment.joblib').absolute(), compress=('gzip', 9))
 
+
 def load(model_name='food_sentiment'):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 def evaluate(scoring='f1', max_rows=-1):
+    """Evaluates the pretrained model on test set by given metric.
+
+    Parameters
+    ----------
+    scoring: str, default='f1'
+        Scoring metric for evaluation. Can be 'f1' for f-1 macro score or
+        'auc' for roc-auc score.
+    max_rows: int, default=-1
+        Number of test instances to be sampled for evaluating the model.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/food_reviews_multilabel.py
+++ b/sadedegel/prebuilt/food_reviews_multilabel.py
@@ -18,6 +18,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc('icu')),
          ('hash', HashVectorizer(n_features=550000, alternate_sign=False)),
@@ -31,6 +39,24 @@ cols = ['speed', 'service', 'flavour']
 
 
 def build(max_rows=-1, save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    max_rows: int, default=-1
+        Number of instances to be sampled for training the model.
+    save: bool, default=True
+        Whether to save the model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -66,10 +92,41 @@ def build(max_rows=-1, save=True):
 
 
 def load(model_name='food_sentiment_multilabel'):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 
 def evaluate(scoring='f1', max_rows=-1):
+    """Evaluates the pretrained model on test set by given metric.
+
+    Parameters
+    ----------
+    scoring: str, default='f1'
+        Scoring metric for evaluation. Can be 'f1' for f-1 macro score or
+        'auc' for roc-auc score.
+    max_rows: int, default=-1
+        Number of test instances to be sampled for evaluating the model.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/hotel_sentiment.py
+++ b/sadedegel/prebuilt/hotel_sentiment.py
@@ -17,6 +17,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc("icu")),
          ('hash', HashVectorizer(n_features=44995, alternate_sign=True)),
@@ -25,6 +33,22 @@ def empty_model():
 
 
 def build(save=True):
+    """Function to train, evaluate and save a model pipeline.
+
+    Parameters
+    ----------
+    save: bool, default=True
+        Whether to save the model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -58,10 +82,38 @@ def build(save=True):
 
 
 def load(model_name="hotel_sentiment_classification"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 
 def evaluate(model=None):
+    """Evaluates the pretrained model by accuracy score.
+
+    Parameters
+    ----------
+    model:str
+        Model name to be evaluated.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/movie_reviews.py
+++ b/sadedegel/prebuilt/movie_reviews.py
@@ -17,6 +17,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc('icu')),
          ('tfidf', TfidfVectorizer(tf_method='log_norm', idf_method='smooth', drop_punct=True,
@@ -27,6 +35,24 @@ def empty_model():
 
 
 def build(max_rows=-1, save=True):
+    """Function to build and save a model pipeline.
+
+    Parameters
+    ----------
+    max_rows: int, default=-1
+        Number of instances to be sampled for training the model.
+    save: bool, default=True
+        Whether to save model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -60,12 +86,35 @@ def build(max_rows=-1, save=True):
 
 
 def load(model_name="movie_sentiment"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
     return pipeline
 
 
 def evaluate():
+    """Evaluates the pretrained model on test data and gives results.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/news_classification.py
+++ b/sadedegel/prebuilt/news_classification.py
@@ -21,6 +21,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    OnlinePipeline: object
+        sadedegel's on the fly pipeline.
+    """
     return OnlinePipeline(
         [('text2doc', Text2Doc("icu")),
          ('tfidf', TfidfVectorizer(tf_method='log_norm', idf_method='smooth', drop_punct=True, drop_stopwords=False,
@@ -30,6 +38,24 @@ def empty_model():
 
 
 def build(max_rows=-1, batch_size=10000):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    max_rows: int, default=-1
+        Number of instances to be sampled for training the model.
+    batch_size: int, default=10000
+        Number of instances to be trained per mini-batch.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -76,6 +102,18 @@ def build(max_rows=-1, batch_size=10000):
 
 
 def load(model_name="news_classification"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 

--- a/sadedegel/prebuilt/telco_sentiment.py
+++ b/sadedegel/prebuilt/telco_sentiment.py
@@ -17,6 +17,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc("icu", emoji=True, hashtag=True, mention=True)),
          ('hash', HashVectorizer(n_features=1033297, alternate_sign=False)),
@@ -25,6 +33,22 @@ def empty_model():
 
 
 def build(save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    save: bool, default=True
+        Whether to save model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -58,10 +82,37 @@ def build(save=True):
 
 
 def load(model_name="telco_sentiment_classification"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 
 def evaluate(model=None):
+    """Evaluates the pretrained model on test data and gives results.
+    Parameters
+    ----------
+    model: str
+        Model name to be evaluated.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/tweet_profanity.py
+++ b/sadedegel/prebuilt/tweet_profanity.py
@@ -17,6 +17,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc("icu")),
          ('hash', HashVectorizer(n_features=413833, alternate_sign=False)),
@@ -25,6 +33,22 @@ def empty_model():
 
 
 def build(save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    save: bool, default=True
+        Whether to save model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -58,10 +82,37 @@ def build(save=True):
 
 
 def load(model_name="tweet_profanity_classification"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 
 def evaluate(model=None):
+    """Evaluates the pretrained model on test data and gives results.
+    Parameters
+    ----------
+    model: str, default=None
+        Model name to be evaluated.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:

--- a/sadedegel/prebuilt/tweet_sentiment.py
+++ b/sadedegel/prebuilt/tweet_sentiment.py
@@ -23,6 +23,14 @@ console = Console()
 
 
 def empty_model():
+    """Creates a sadedegel compatible sklearn pipeline which can
+    tokenize, vectorize and train a model of a given text.
+
+    Returns
+    -------
+    Pipeline: object
+        sklearn.pipeline.Pipeline object.
+    """
     return Pipeline(
         [('text2doc', Text2Doc("icu")),
          ('hash', HashVectorizer(n_features=932380, alternate_sign=True)),
@@ -32,6 +40,24 @@ def empty_model():
 
 
 def cv(k=3, max_instances=-1):
+    """Trains and evaluates the given dataset using 'K-Fold'.
+
+    Parameters
+    ----------
+    k: int, default=3
+        Number of folds to train and evaluate.
+    max_instances: int, default=-1
+        Number of instances to use in training.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -74,6 +100,24 @@ def cv(k=3, max_instances=-1):
 
 
 def build(max_instances=-1, save=True):
+    """Function to train and save a model pipeline.
+
+    Parameters
+    ----------
+    max_instances: int, default=-1
+        Number of instances to be sampled for training the model.
+    save: bool, default=True
+        Whether to save the model or not.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ImportError
+        If 'pandas' is not installed.
+    """
     try:
         import pandas as pd
     except ImportError:
@@ -114,6 +158,18 @@ def build(max_instances=-1, save=True):
 
 
 def load(model_name="tweet_sentiment"):
+    """Loads the prebuilt model.
+
+    Parameters
+    ----------
+    model_name: str
+        Name of the model .joblib file to be loaded.
+
+    Returns
+    -------
+    load_model: object
+        sklearn.pipeline.Pipeline object.
+    """
     return load_model(model_name)
 
 

--- a/sadedegel/prebuilt/util.py
+++ b/sadedegel/prebuilt/util.py
@@ -4,6 +4,19 @@ from os.path import dirname
 
 
 def load_model(model_name: str):
+    """Loads prebuilt model for inference.
+
+    Parameters
+    ----------
+    model_name: str
+        Model name to be loaded.
+
+    Returns
+    -------
+    pipeline: object
+        sklearn.pipeline.Pipeline object.
+
+    """
     pipeline = jl_load(Path(dirname(__file__)) / 'model' / f"{model_name}.joblib")
 
     pipeline.steps[0][1].init()

--- a/tests/extension/test_pretrained_vectorizer.py
+++ b/tests/extension/test_pretrained_vectorizer.py
@@ -3,7 +3,7 @@ import pkgutil  # noqa: F401 # pylint: disable=unused-import
 import pytest
 import numpy as np
 
-from .context import PreTrainedVectorizer, load_tweet_sentiment_train
+from .context import PreTrainedVectorizer, load_tweet_sentiment_train, Text2Doc
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import cross_val_score
@@ -14,8 +14,9 @@ mini_corpus = ['Sabah bir tweet', 'Öğlen bir başka tweet', 'Akşam bir tweet'
 
 @pytest.mark.skipif('pkgutil.find_loader("transformers") is None')
 def test_vectorizer_pipeline():
-    vecpipe = Pipeline([("bert_doc_embeddings",
-                         PreTrainedVectorizer(model="distilbert", do_sents=False, progress_tracking=False))])
+    vecpipe = Pipeline([("text2doc", Text2Doc()),
+                        ("bert_doc_embeddings",
+                         PreTrainedVectorizer(model="distilbert", do_sents=False, show_progress=False))])
     embs = vecpipe.fit_transform(mini_corpus)
 
     assert embs.shape[0] == len(mini_corpus)
@@ -24,8 +25,9 @@ def test_vectorizer_pipeline():
 @pytest.mark.skipif('pkgutil.find_loader("transformers") is None')
 @pytest.mark.parametrize("do_sents", [True, False])
 def test_vectorizer_sparse_to_array(do_sents):
-    vecpipe = Pipeline([("bert_doc_embeddings",
-                         PreTrainedVectorizer(model="distilbert", do_sents=do_sents, progress_tracking=False))])
+    vecpipe = Pipeline([("text2doc", Text2Doc()),
+                        ("bert_doc_embeddings",
+                         PreTrainedVectorizer(model="distilbert", do_sents=do_sents, show_progress=False))])
     embs = vecpipe.fit_transform(mini_corpus)
     embs_npy = embs.toarray()
 
@@ -36,10 +38,11 @@ def test_vectorizer_sparse_to_array(do_sents):
 
 @pytest.mark.skipif('pkgutil.find_loader("transformers") is None')
 def test_pipeline_fit():
-    vec = PreTrainedVectorizer(model="distilbert", do_sents=False, progress_tracking=False)
+    vec = PreTrainedVectorizer(model="distilbert", do_sents=False, show_progress=False)
     lr = LogisticRegression(C=0.123)
 
-    vecpipe = Pipeline([("distilbert_embeddings", vec),
+    vecpipe = Pipeline([("text2doc", Text2Doc()),
+                        ("distilbert_embeddings", vec),
                         ("logreg", lr)])
     X = ["harika bir ürün. kargo da çabuk ulaştı.", "kahve makinam diyarbakıra gitmiş. yapacağınız işi sikeyim."] * 5
     y = [1.0, 0.0] * 5

--- a/tests/extension/test_text2doc.py
+++ b/tests/extension/test_text2doc.py
@@ -1,0 +1,26 @@
+from itertools import permutations
+import pytest
+from .context import Text2Doc
+
+preprocess_settings = list(set(permutations([True, True, True, True, False, False, False], 4)))
+
+
+@pytest.mark.parametrize("settings", preprocess_settings)
+def test_text2doc_change(settings):
+    vec = Text2Doc(hashtag=settings[0],
+                   mention=settings[1],
+                   emoji=settings[2],
+                   emoticon=settings[3])
+    assert vec.Doc.tokenizer.hashtag == settings[0]
+    assert vec.Doc.tokenizer.mention == settings[1]
+    assert vec.Doc.tokenizer.emoji == settings[2]
+    assert vec.Doc.tokenizer.emoticon == settings[3]
+
+    vec = Text2Doc(hashtag=settings[3],
+                   mention=settings[2],
+                   emoji=settings[1],
+                   emoticon=settings[0])
+    assert vec.Doc.tokenizer.hashtag == settings[3]
+    assert vec.Doc.tokenizer.mention == settings[2]
+    assert vec.Doc.tokenizer.emoji == settings[1]
+    assert vec.Doc.tokenizer.emoticon == settings[0]


### PR DESCRIPTION
- Added proper ways to use pre-processing in transformer based vectorizers where they used to work on raw strings.
- Added ability to use pre-trained vectorizers and Text2Doc together in pipelines.
- Text2Doc settings should be properly changing after altering the settings.
- Added test cases for changes mentioned above.