### PR TITLE
Implement download API for public datasets.

### DIFF
--- a/sadedegel/dataset/README.md
+++ b/sadedegel/dataset/README.md
@@ -53,7 +53,7 @@ sents = load_annotated_corpus()
 * [extended](extended/) **sents** is generated using [extended](extended/) **raw** and ML based sentence boundary detector trained over [sents](sents/) corpus
 
 
-### Download Dataset
+### Download Private Dataset
 
 You can download extended dataset using
 
@@ -124,8 +124,18 @@ Validation process ensures that hand annotated sentence tokenization does not vi
 ```bash
 python -m sadedegel.dataset validate
 ```
+# Public Datasets
+### Download Public Datasets
 
-## `tscorpus`
+```python
+import sadedegel as sg
+
+sg.dataset.download("<dataset_name>")
+```
+
+Public datasets, their names and usage are listed below.
+
+## `ts_corpus`
 
 [tscorpus] is an invaluable contribution by [Taner Sezer].
 

--- a/sadedegel/dataset/__init__.py
+++ b/sadedegel/dataset/__init__.py
@@ -1,1 +1,2 @@
 from ._core import load_raw_corpus, load_sentence_corpus, load_annotated_corpus, file_paths, CorpusTypeEnum  # noqa: F401
+from ._download import download

--- a/sadedegel/dataset/_download.py
+++ b/sadedegel/dataset/_download.py
@@ -1,0 +1,67 @@
+from zipfile import ZipFile
+from smart_open import open
+from pathlib import Path
+from rich.console import Console
+import os
+import gzip
+from shutil import copyfileobj
+
+
+console = Console()
+
+url_mapping = {
+    "hotel_sentiment": "https://storage.googleapis.com/sadedegel/dataset/hotel_sentiment.zip",
+    "categorized_prdoduct_sentiment": "https://storage.googleapis.com/sadedegel/dataset/categorized_product_sentiment.csv.gz",
+    "movie_sentiment": "https://storage.googleapis.com/sadedegel/dataset/movie_sentiment.zip",
+    "profanity": "https://storage.googleapis.com/sadedegel/dataset/offenseval2020-turkish.zip",
+    "telco_sentiment": "https://storage.googleapis.com/sadedegel/dataset/telco_sentiment.zip",
+    "tweet_sentiment": "https://storage.googleapis.com/sadedegel/dataset/tweet_sentiment_train.csv.gz",
+    "product_sentiment": "https://storage.googleapis.com/sadedegel/dataset/product_sentiment.csv.gz",
+    "customer_review": "https://storage.googleapis.com/sadedegel/dataset/customer_review_classification.zip",
+    "food_review": "https://storage.googleapis.com/sadedegel/dataset/food_review.zip",
+    "spam": "https://storage.googleapis.com/sadedegel/dataset/spam.csv.gz"
+}
+
+ts_corpus_tarballs = ["art_culture.jsonl.gz", "education.jsonl.gz", "horoscope.jsonl.gz", "life_food.jsonl.gz",
+                      "politics.jsonl.gz", "technology.jsonl.gz", "economics.jsonl.gz", "health.jsonl.gz",
+                      "life.jsonl.gz", "magazine.jsonl.gz", "sports.jsonl.gz", "travel.jsonl.gz"]
+
+ts_corpus_fmts = ["raw", "tokenized"]
+
+
+def form_directory(url: str, data_home="~/.sadedegel_data"):
+    data_home = Path(os.path.expanduser(data_home))
+
+    if "tscorpus" in url:
+        data_home = data_home / 'tscorpus'
+        for fmt in ts_corpus_fmts:
+            (data_home / fmt).mkdir(parents=True, exist_ok=True)
+            with console.status(f"[bold green]Downloading {fmt}...") as status:
+                for tarball in ts_corpus_tarballs:
+                    tb_url = f"{url}/{fmt}/{tarball}"
+                    with open(tb_url, 'rb') as fp, open(data_home / fmt / tarball, "wb") as wp:
+                        wp.write(fp.read())
+
+                    console.log(f"{fmt}/{tarball} complete.")
+
+    else:
+        data_home.mkdir(parents=True, exist_ok=True)
+        with console.status(f"[bold blue]Downloading {url.split('/')[-1]}"):
+            if "gz" in url:
+                with open(url, 'rb') as fp, gzip.open(data_home / os.path.basename(url), "wb") as wp:
+                    copyfileobj(fp, wp)
+            else:
+                with open(url, 'rb') as fp:
+                    with ZipFile(fp) as zp:
+                        zp.extractall(data_home)
+
+
+def download(dataset: str):
+    if dataset in url_mapping.keys():
+        url = url_mapping.get(dataset, None)
+    elif dataset == "ts_corpus":
+        url = "https://storage.googleapis.com/sadedegel/dataset/tscorpus"
+    else:
+        raise NotImplementedError(f"Dataset named {dataset} is not a part of sadedegel.dataset family. "
+                                  f"Available datasets are: {list(url_mapping.keys()) + ['ts_corpus']}")
+    form_directory(url)

--- a/sadedegel/dataset/_download.py
+++ b/sadedegel/dataset/_download.py
@@ -43,11 +43,9 @@ def form_directory(url: str, data_home="~/.sadedegel_data"):
                         wp.write(fp.read())
 
                     console.log(f"{fmt}/{tarball} complete.")
-
     else:
         data_home.mkdir(parents=True, exist_ok=True)
         with console.status(f"[bold blue]Downloading {url.split('/')[-1]}"):
-<<<<<<< HEAD
             if "gz" in url:
                 with open(url, 'rb') as fp, gzip.open(data_home / os.path.basename(url), "wb") as wp:
                     copyfileobj(fp, wp)
@@ -55,11 +53,6 @@ def form_directory(url: str, data_home="~/.sadedegel_data"):
                 with open(url, 'rb') as fp:
                     with ZipFile(fp) as zp:
                         zp.extractall(data_home)
-=======
-            with open(url, 'rb') as fp:
-                with ZipFile(fp) as zp:
-                    zp.extractall(data_home)
->>>>>>> 08d03e426e1b851b667cc9434fb439f3b4091bd5
 
 
 def download(dataset: str):

--- a/sadedegel/dataset/_download.py
+++ b/sadedegel/dataset/_download.py
@@ -47,7 +47,11 @@ def form_directory(url: str, data_home="~/.sadedegel_data"):
         data_home.mkdir(parents=True, exist_ok=True)
         with console.status(f"[bold blue]Downloading {url.split('/')[-1]}"):
             if "gz" in url:
-                with open(url, 'rb') as fp, gzip.open(data_home / os.path.basename(url), "wb") as wp:
+                name = url.split('/')[-1]
+                folder = name.split(".csv.gz")[0]
+                data_home = data_home / folder
+                data_home.mkdir(parents=True, exist_ok=True)
+                with open(url, 'rb') as fp, gzip.open(data_home / name, "wb") as wp:
                     copyfileobj(fp, wp)
             else:
                 with open(url, 'rb') as fp:

--- a/sadedegel/dataset/_download.py
+++ b/sadedegel/dataset/_download.py
@@ -1,0 +1,59 @@
+from zipfile import ZipFile
+from smart_open import open
+from pathlib import Path
+from rich.console import Console
+import os
+
+console = Console()
+
+url_mapping = {
+    "hotel_sentiment": "https://storage.googleapis.com/sadedegel/dataset/hotel_sentiment.zip",
+    "categorized_prdoduct_sentiment": "https://storage.googleapis.com/sadedegel/dataset/categorized_product_sentiment.csv.gz",
+    "movie_sentiment": "https://storage.googleapis.com/sadedegel/dataset/movie_sentiment.zip",
+    "profanity": "https://storage.googleapis.com/sadedegel/dataset/offenseval2020-turkish.zip",
+    "telco_sentiment": "https://storage.googleapis.com/sadedegel/dataset/telco_sentiment.zip",
+    "tweet_sentiment": "https://storage.googleapis.com/sadedegel/dataset/tweet_sentiment_train.csv.gz",
+    "product_sentiment": "https://storage.googleapis.com/sadedegel/dataset/product_sentiment.csv.gz",
+    "customer_review": "https://storage.googleapis.com/sadedegel/dataset/customer_review_classification.zip",
+    "food_review": "https://storage.googleapis.com/sadedegel/dataset/food_review.zip"
+}
+
+ts_corpus_tarballs = ["art_culture.jsonl.gz", "education.jsonl.gz", "horoscope.jsonl.gz", "life_food.jsonl.gz",
+                      "politics.jsonl.gz", "technology.jsonl.gz", "economics.jsonl.gz", "health.jsonl.gz",
+                      "life.jsonl.gz", "magazine.jsonl.gz", "sports.jsonl.gz", "travel.jsonl.gz"]
+
+ts_corpus_fmts = ["raw", "tokenized"]
+
+
+def form_directory(url: str, data_home="~/.sadedegel_data"):
+    data_home = Path(os.path.expanduser(data_home))
+
+    if "tscorpus" in url:
+        data_home = data_home / 'tscorpus'
+        for fmt in ts_corpus_fmts:
+            (data_home / fmt).mkdir(parents=True, exist_ok=True)
+            with console.status(f"[bold green]Downloading {fmt}...") as status:
+                for tarball in ts_corpus_tarballs:
+                    tb_url = f"{url}/{fmt}/{tarball}"
+                    with open(tb_url, 'rb') as fp, open(data_home / fmt / tarball, "wb") as wp:
+                        wp.write(fp.read())
+
+                    console.log(f"{fmt}/{tarball} complete.")
+
+    else:
+        data_home.mkdir(parents=True, exist_ok=True)
+        with console.status(f"[bold blue]Downloading {url.split('/')[-1]}"):
+            with open(url, 'rb') as fp:
+                with ZipFile(fp) as zp:
+                    zp.extractall(data_home)
+
+
+def download(dataset: str):
+    if dataset in url_mapping.keys():
+        url = url_mapping.get(dataset, None)
+    elif dataset == "ts_corpus":
+        url = "https://storage.googleapis.com/sadedegel/dataset/tscorpus"
+    else:
+        raise NotImplementedError(f"Dataset named {dataset} is not a part of sadedegel.dataset family. "
+                                  f"Available datasets are: {list(url_mapping.keys()) + ['ts_corpus']}")
+    form_directory(url)


### PR DESCRIPTION
- Public datasets require access and secret keys for the bucket.
- Implement a `dataset.download` function that receives the string alias for a `sadedegel` public dataset.
- Download zips from public URLs from the bucket.
- Update datasets README with public dataset download example.